### PR TITLE
Fix: SQLite-compatible UPDATE queries and add_model_key_to_db bug

### DIFF
--- a/backend/api_endpoints/financeGPT/chatbot_endpoints.py
+++ b/backend/api_endpoints/financeGPT/chatbot_endpoints.py
@@ -56,9 +56,8 @@ def update_chat_name_db(chat_id, new_name):
 
     query = """
     UPDATE chats
-    JOIN users ON chats.user_id = users.id
-    SET chats.chat_name = ?
-    WHERE chats.id = ? AND users.id = ?;
+    SET chat_name = ?
+    WHERE id = ? AND user_id = ?;
     """
     cursor.execute(query, (new_name, chat_id, USER_ID))
 
@@ -229,11 +228,10 @@ def change_chat_mode_db(chat_mode_to_change_to, chat_id):
 
     query = """
     UPDATE chats
-    JOIN users ON chats.user_id = users.id
-    SET chats.model_type = ?
-    WHERE chats.id = ? AND users.id = ?;
+    SET model_type = ?
+    WHERE id = ? AND user_id = ?;
     """
-    
+
     # Execute the query
     cursor.execute(query, (chat_mode_to_change_to, chat_id, USER_ID))
 
@@ -452,19 +450,19 @@ def delete_doc_from_db(doc_id):
 
     return "success"
 
-def add_model_key_to_db(model_key, chat_id, user_email):
+def add_model_key_to_db(model_key, chat_id, user_email=None):
     conn, cursor = get_db_connection()
 
     update_query = """
         UPDATE chats
-        JOIN users ON chats.user_id = users.id
-        SET chats.custom_model_key = ?
-        WHERE chats.id = ? AND users.email = ?;
+        SET custom_model_key = ?
+        WHERE id = ? AND user_id = ?;
         """
 
     cursor.execute(update_query, (model_key, chat_id, USER_ID))
 
     conn.commit()
+    conn.close()
 
 #For edgar
 queryApi = QueryApi(api_key=sec_api_key)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Three bugs in `backend/api_endpoints/financeGPT/chatbot_endpoints.py` that break the SQLite-backed desktop build:

- **Bug 1 — `update_chat_name_db`**: Used MySQL-only `UPDATE ... JOIN` syntax, which SQLite does not support. Replaced with a standard `UPDATE ... WHERE` query using `id` and `user_id` columns directly.

- **Bug 2 — `change_chat_mode_db`**: Same MySQL-only `UPDATE ... JOIN` pattern. Fixed identically — rewritten as a straightforward `UPDATE chats SET model_type = ? WHERE id = ? AND user_id = ?`.

- **Bug 3 — `add_model_key_to_db`**: Two problems in one function:
  1. MySQL-only `UPDATE ... JOIN users` syntax (same class of bug as above).
  2. The bound parameter for `users.email` was incorrectly passing `USER_ID` (an integer) instead of `user_email` (a string), causing the `WHERE` clause to never match and silently updating nothing.
  
  Fix: removed the JOIN entirely, rewrote as `UPDATE chats SET custom_model_key = ? WHERE id = ? AND user_id = ?`, made `user_email` an optional param (kept for call-site compatibility), and added the missing `conn.close()` call.

## Test plan

- [ ] Start the desktop (SQLite) build and create a new chat
- [ ] Rename the chat — verifies `update_chat_name_db` executes without error and the name persists
- [ ] Switch the chat mode (PDF / EDGAR / API Key) — verifies `change_chat_mode_db` executes and the mode persists
- [ ] Enter a custom OpenAI API key in the chat settings — verifies `add_model_key_to_db` actually writes the key to the DB (previously silently failed)
- [ ] Confirm SELECT-based functions (`retrieve_chats_from_db`, `retrieve_message_from_db`) are unaffected — JOIN in SELECT is valid SQLite syntax and was left untouched

https://claude.ai/code/session_01WwtoQcP5VdJbWj8ERKN5GG
EOF
)