### PR TITLE
Feature: implement custom OpenAI API key in chat endpoint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -360,7 +360,23 @@ def process_message_pdf():
     )
     user_prompt = f"Document sources:\n{sources_str}\n\nQuestion: {query}"
 
-    if model_type == 0:
+    if model_key:
+        # Use custom OpenAI API key
+        try:
+            import openai as _openai
+            client = _openai.OpenAI(api_key=model_key)
+            response = client.chat.completions.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=0.3,
+            )
+            answer = response.choices[0].message.content.strip()
+        except Exception as e:
+            return jsonify({"error": f"OpenAI API error: {str(e)}"}), 500
+    elif model_type == 0:
         try:
             response = ollama.chat(model='llama2', messages=[
                 {'role': 'system', 'content': system_prompt},


### PR DESCRIPTION
## Summary

- **Bug fixed:** The `/process-message-pdf` endpoint accepted a `model_key` field in its request body but silently ignored it — every request was always routed to Ollama (llama2 or mistral) regardless of whether the user had provided their own OpenAI API key via the Settings panel.
- **Fix:** Added a priority check at the top of the model-routing block. When `model_key` is a non-empty string, the endpoint now uses the OpenAI Python client with `gpt-3.5-turbo` and the provided key. Only when no key is present does it fall back to the existing Ollama routing (`model_type == 0` → llama2, otherwise → mistral).
- **Priority order:** Custom OpenAI key > llama2 (model_type 0) > mistral (model_type 1).

## Test plan

- [ ] Send a `/process-message-pdf` request with a valid `model_key` (OpenAI API key) and verify the response comes from `gpt-3.5-turbo` (e.g., check response style/content or mock the OpenAI client).
- [ ] Send a request with `model_key` omitted or empty and `model_type: 0` — verify llama2 is used via Ollama.
- [ ] Send a request with `model_key` omitted or empty and `model_type: 1` — verify mistral is used via Ollama.
- [ ] Send a request with an invalid `model_key` — verify the endpoint returns a 500 with an `"OpenAI API error: ..."` message rather than crashing silently.
- [ ] Confirm existing PDF chat flows (without API key) are unaffected.

https://claude.ai/code/session_01WwtoQcP5VdJbWj8ERKN5GG