### PR TITLE
Fix: infer-chat-name respects active model with graceful fallback

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -454,17 +454,29 @@ def process_ticker_info():
 def infer_chat_name():
     messages = request.json.get('messages', '')
     chat_id = request.json.get('chat_id')
+    model_type = request.json.get('model_type', 1)  # 0=llama2, 1=mistral
 
-    try:
-        response = ollama.chat(model='mistral', messages=[
-            {
-                'role': 'user',
-                'content': f'Generate a short 3-5 word chat title for this conversation snippet. Reply with only the title, no punctuation or quotes:\n\n{messages[:500]}'
-            },
-        ])
-        chat_name = response['message']['content'].strip()[:60]
-    except Exception:
-        chat_name = f"Chat {chat_id}"
+    prompt_msg = [{
+        'role': 'user',
+        'content': f'Generate a short 3-5 word chat title for this conversation snippet. Reply with only the title, no punctuation or quotes:\n\n{messages[:500]}'
+    }]
+
+    # Try preferred model first, then the other, then word-truncation fallback
+    models_to_try = ['mistral', 'llama2'] if model_type == 1 else ['llama2', 'mistral']
+    chat_name = None
+
+    for model in models_to_try:
+        try:
+            response = ollama.chat(model=model, messages=prompt_msg)
+            chat_name = response['message']['content'].strip()[:60]
+            break
+        except Exception:
+            continue
+
+    if not chat_name:
+        # Word-truncation fallback — use first 5 words of the conversation
+        words = messages.strip().split()
+        chat_name = ' '.join(words[:5]) or f'Chat {chat_id}'
 
     update_chat_name_db(chat_id, chat_name)
     return jsonify(chat_name=chat_name)


### PR DESCRIPTION
## Summary

- **Bug**: The `/infer-chat-name` endpoint hardcoded `model='mistral'` in its `ollama.chat()` call. If the user had LLaMA 2 selected (or neither model installed), the call would silently fail and fall back to `"Chat {id}"` — the least helpful possible name.
- **Fix (backend)**: The endpoint now reads a `model_type` field from the request payload (0 = llama2, 1 = mistral). It builds an ordered list — preferred model first, other model second — and iterates through them, stopping on the first success. If both Ollama calls fail, it falls back to the first 5 words of the conversation text as the chat name (e.g. `"What was Apple's revenue last"`) rather than the generic `"Chat {id}"`.
- **Fix (frontend)**: `ChatbotEdgar.js` now includes `model_type: props.isPrivate` in the `inferChatName` fetch payload so the backend knows which model the user has selected.

## Test plan

- [ ] Start the app with only LLaMA 2 installed; send a first message in an EDGAR chat and confirm the chat is renamed to something meaningful (not `"Chat 1"`).
- [ ] Start the app with only Mistral installed; same check.
- [ ] Start the app with no local models installed (API key mode); confirm the chat name falls back to the first few words of the conversation, not `"Chat {id}"`.
- [ ] Start with both models installed and `model_type=1` (Mistral selected); confirm Mistral is used for naming.
- [ ] Start with both models installed and `model_type=0` (LLaMA 2 selected); confirm LLaMA 2 is tried first.

https://claude.ai/code/session_01WwtoQcP5VdJbWj8ERKN5GG