### PR TITLE
Stabilize chat session state

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { BrowserRouter as Router, Navigate, Route, Routes } from "react-router-dom";
 import HomeChatbot from "./financeGPT/components/Home.js";
 
 function App() {
@@ -7,6 +7,7 @@ function App() {
     <Router>
       <Routes>
         <Route path="/" element={<HomeChatbot />} />
+        <Route path="*" element={<Navigate replace to="/" />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/financeGPT/components/ChatHistory.js
+++ b/frontend/src/financeGPT/components/ChatHistory.js
@@ -12,6 +12,8 @@ function ChatHistory(props) {
   const [chatIdToRename, setChatIdToRename] = useState(null);
   const [newChatName, setNewChatName] = useState("");
 
+  // This list refreshes only when the selected chat changes or callers force a reload.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     retrieveAllChats();
   }, [props.selectedChatId, props.forceUpdate]);
@@ -24,7 +26,6 @@ function ChatHistory(props) {
   const confirmDeleteChat = () => {
     deleteChat(chatToDelete);
     setShowConfirmPopupChat(false);
-    props.onChatSelect(null);
   };
 
   const handleRenameChat = (chat_id) => {
@@ -46,7 +47,7 @@ function ChatHistory(props) {
         body: JSON.stringify({ chat_type: props.chat_type }),
       });
       const response_data = await response.json();
-      setChats(response_data.chat_info);
+      setChats(response_data.chat_info || []);
     } catch (error) {
       console.error("Error fetching chats:", error);
     }
@@ -62,14 +63,22 @@ function ChatHistory(props) {
       if (response.ok) {
         props.handleForceUpdate();
         try {
-          const recentRes = await fetcher("find-most-recent-chat", {
+          const chatsRes = await fetcher("retrieve-all-chats", {
             method: "POST",
             headers: { Accept: "application/json", "Content-Type": "application/json" },
             body: JSON.stringify({}),
           });
-          const recentData = await recentRes.json();
-          props.handleChatSelect(recentData.chat_info.id);
-          props.setCurrChatName(recentData.chat_info.chat_name);
+          const chatsData = await chatsRes.json();
+          const updatedChats = chatsData.chat_info || [];
+          setChats(updatedChats);
+
+          if (updatedChats.length === 0) {
+            props.onChatSelect(null);
+            return;
+          }
+
+          const mostRecentChat = [...updatedChats].sort((a, b) => b.id - a.id)[0];
+          props.onChatSelect(mostRecentChat);
         } catch (e) {
           console.error("Error finding recent chat after deletion", e);
         }
@@ -80,12 +89,21 @@ function ChatHistory(props) {
   };
 
   const renameChat = async (chat_id, new_name) => {
+    const trimmedName = new_name.trim();
+
+    if (!trimmedName) {
+      return;
+    }
+
     try {
       await fetcher("update-chat-name", {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
-        body: JSON.stringify({ chat_id, chat_name: new_name }),
+        body: JSON.stringify({ chat_id, chat_name: trimmedName }),
       });
+      if (chat_id === props.selectedChatId) {
+        props.setCurrChatName(trimmedName);
+      }
       retrieveAllChats();
     } catch (e) {
       console.error("Error renaming chat:", e);
@@ -161,15 +179,8 @@ function ChatHistory(props) {
           onClick={() => {
             props
               .createNewChat()
-              .then((newChatId) => {
-                const chat_name = "Chat " + newChatId;
-                props.setIsPrivate(0);
-                props.setCurrChatName(chat_name);
-                props.setTicker("");
-                props.setShowChatbot(false);
-                props.onChatSelect(newChatId);
+              .then(() => {
                 props.handleForceUpdate();
-                props.setConfirmedModelKey("");
               })
               .catch((error) => console.error("Error creating new chat:", error));
           }}
@@ -187,15 +198,7 @@ function ChatHistory(props) {
           <div
             key={chat.id}
             onClick={() => {
-              props.onChatSelect(chat.id);
-              props.setIsPrivate(chat.model_type);
-              props.setTicker(chat.ticker);
-              if (chat.ticker) {
-                props.setIsEdit(0);
-                props.setShowChatbot(true);
-              }
-              props.setcurrTask(chat.associated_task);
-              props.setCurrChatName(chat.chat_name);
+              props.onChatSelect(chat);
             }}
             className={`flex items-center justify-between px-2 py-2 rounded-lg cursor-pointer transition-colors group ${
               props.selectedChatId === chat.id

--- a/frontend/src/financeGPT/components/Chatbot.js
+++ b/frontend/src/financeGPT/components/Chatbot.js
@@ -25,19 +25,14 @@ const Chatbot = (props) => {
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = React.useState(0);
   const [timeLeft, setTimeLeft] = React.useState("");
+  const welcomeMessage = {
+    message: "Hello, I am your financial assistant, how can I help you?",
+    sentTime: "just now",
+    direction: "incoming",
+  };
 
-  useEffect(() => {
-    loadLatestChat();
-    handleLoadChat();
-    setMessages([
-      {
-        message: "Hello, I am your financial assistant, how can I help you?",
-        sentTime: "just now",
-        direction: "incoming",
-      },
-    ]);
-  }, []);
-
+  // Chat history reloads are intentionally driven by chat selection plus explicit refreshes.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     handleLoadChat();
   }, [props.selectedChatId, props.forceUpdate]);
@@ -47,24 +42,6 @@ const Chatbot = (props) => {
       behavior: "smooth",
       block: "end",
     });
-  };
-
-  const loadLatestChat = async () => {
-    try {
-      const response = await fetcher("find-most-recent-chat", {
-        method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({}),
-      });
-      const response_data = await response.json();
-      props.handleChatSelect(response_data.chat_info.id);
-      props.setCurrChatName(response_data.chat_info.chat_name);
-    } catch (e) {
-      console.error("Error loading latest chat", e);
-    }
   };
 
   const handleDownload = async () => {
@@ -95,15 +72,15 @@ const Chatbot = (props) => {
   const handleTryMessage = (text, chat_id, isPrivate) => {
     if (!text.trim()) return;
     if (chat_id === null || chat_id === undefined) {
-      props.createNewChat().then((newChatId) => {
-        if (newChatId) handleSendMessage(text, newChatId, isPrivate);
+      props.createNewChat(props.chat_type, isPrivate, false).then((newChat) => {
+        if (newChat?.id) handleSendMessage(text, newChat.id, newChat);
       });
     } else {
-      handleSendMessage(text, chat_id, isPrivate);
+      handleSendMessage(text, chat_id);
     }
   };
 
-  const handleSendMessage = async (text, chat_id) => {
+  const handleSendMessage = async (text, chat_id, newChat = null) => {
     if (inputRef.current) {
       inputRef.current.value = "";
       inputRef.current.style.height = "auto";
@@ -141,6 +118,9 @@ const Chatbot = (props) => {
             : msg
         )
       );
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
       handleLoadChat();
       scrollToBottom();
     } catch (e) {
@@ -151,6 +131,9 @@ const Chatbot = (props) => {
             : msg
         )
       );
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
       setShowInstallationModal(true);
     }
   };
@@ -200,6 +183,12 @@ const Chatbot = (props) => {
   };
 
   const handleLoadChat = async () => {
+    setMessages([welcomeMessage]);
+
+    if (props.selectedChatId === null || props.selectedChatId === undefined) {
+      return;
+    }
+
     try {
       const response = await fetcher("retrieve-messages-from-chat", {
         method: "POST",
@@ -213,39 +202,35 @@ const Chatbot = (props) => {
         }),
       });
 
-      setMessages([
-        {
-          message: "Hello, I am your financial assistant, how can I help you?",
-          sentTime: "just now",
-          direction: "incoming",
-        },
-      ]);
-
       const response_data = await response.json();
       const transformedMessages = response_data.messages.map((item) => ({
         message: item.message_text,
         direction: item.sent_from_user === 1 ? "outgoing" : "incoming",
         relevant_chunks: item.relevant_chunks,
       }));
-      setMessages((prev) => [...prev, ...transformedMessages]);
+      setMessages([welcomeMessage, ...transformedMessages]);
     } catch (error) {
       console.error("Error loading chat messages:", error);
     }
   };
 
   const handleReset = async () => {
+    if (props.selectedChatId === null || props.selectedChatId === undefined) {
+      setMessages([welcomeMessage]);
+      return;
+    }
+
     try {
-      await fetcher("reset-everything", { method: "POST" });
+      await fetcher("reset-chat", {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: props.selectedChatId }),
+      });
+      props.handleForceUpdate();
     } catch (e) {
       console.error("Failed to reset:", e);
     }
-    setMessages([
-      {
-        message: "Hello, I am your financial assistant, how can I help you?",
-        sentTime: "just now",
-        direction: "incoming",
-      },
-    ]);
+    setMessages([welcomeMessage]);
   };
 
   const handleTextareaInput = (e) => {

--- a/frontend/src/financeGPT/components/Home.js
+++ b/frontend/src/financeGPT/components/Home.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Navbarchatbot from "./NavbarChatbot";
 import Chatbot from "./Chatbot";
 import "../styles/Chatbot.css";
@@ -20,32 +20,95 @@ function HomeChatbot() {
   const [relevantChunk, setRelevantChunk] = useState("");
   const [confirmedModelKey, setConfirmedModelKey] = useState("");
 
-  const handleChatSelect = (chatId) => {
-    setSelectedChatId(chatId);
+  const activateChat = (chatSummary) => {
+    if (!chatSummary) {
+      setSelectedChatId(null);
+      setCurrChatName("");
+      setTicker("");
+      setShowChatbot(false);
+      setIsEdit(0);
+      setConfirmedModelKey("");
+      setActiveMessageIndex(null);
+      setRelevantChunk("");
+      return;
+    }
+
+    setSelectedChatId(chatSummary.id);
+    setIsPrivate(chatSummary.model_type ?? 0);
+    setCurrChatName(chatSummary.chat_name || `Chat ${chatSummary.id}`);
+    setcurrTask(chatSummary.associated_task ?? 0);
+    setTicker(chatSummary.ticker || "");
+    setShowChatbot(chatSummary.associated_task === 1 && Boolean(chatSummary.ticker));
+    setIsEdit(0);
+    setConfirmedModelKey(chatSummary.custom_model_key || "");
+    setActiveMessageIndex(null);
+    setRelevantChunk("");
   };
 
   const handleForceUpdate = () => {
     setForceUpdate((prev) => prev + 1);
   };
 
-  const createNewChat = async () => {
+  useEffect(() => {
+    const loadMostRecentChat = async () => {
+      try {
+        const response = await fetcher("retrieve-all-chats", {
+          method: "POST",
+          headers: { Accept: "application/json", "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        });
+        const responseData = await response.json();
+        const chats = responseData.chat_info || [];
+
+        if (chats.length === 0) {
+          return;
+        }
+
+        const mostRecentChat = [...chats].sort((a, b) => b.id - a.id)[0];
+        activateChat(mostRecentChat);
+      } catch (error) {
+        console.error("Error loading most recent chat:", error);
+      }
+    };
+
+    loadMostRecentChat();
+  }, []);
+
+  const createNewChat = async (
+    taskOverride = currTask,
+    modelOverride = isPrivate,
+    activateSelection = true
+  ) => {
     try {
       const response = await fetcher("create-new-chat", {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
-        body: JSON.stringify({ chat_type: currTask, model_type: isPrivate }),
+        body: JSON.stringify({ chat_type: taskOverride, model_type: modelOverride }),
       });
-      const response_data = await response.json();
-      handleChatSelect(response_data.chat_id);
-      return response_data.chat_id;
+      const responseData = await response.json();
+      const chatSummary = {
+        id: responseData.chat_id,
+        chat_name: `Chat ${responseData.chat_id}`,
+        associated_task: taskOverride,
+        model_type: modelOverride,
+        ticker: "",
+        custom_model_key: "",
+      };
+
+      if (activateSelection) {
+        activateChat(chatSummary);
+      }
+
+      return chatSummary;
     } catch (e) {
       console.error("Error creating new chat:", e);
+      return null;
     }
   };
 
   const sharedChatbotProps = {
     selectedChatId,
-    handleChatSelect,
+    handleChatSelect: activateChat,
     handleForceUpdate,
     forceUpdate,
     isPrivate,
@@ -64,7 +127,7 @@ function HomeChatbot() {
       <div className="w-[20%] px-2">
         <Navbarchatbot
           selectedChatId={selectedChatId}
-          onChatSelect={handleChatSelect}
+          onChatSelect={activateChat}
           handleForceUpdate={handleForceUpdate}
           isPrivate={isPrivate}
           setIsPrivate={setIsPrivate}
@@ -77,7 +140,7 @@ function HomeChatbot() {
           setIsEdit={setIsEdit}
           setShowChatbot={setShowChatbot}
           createNewChat={createNewChat}
-          handleChatSelect={handleChatSelect}
+          handleChatSelect={activateChat}
           forceUpdate={forceUpdate}
         />
       </div>
@@ -106,6 +169,9 @@ function HomeChatbot() {
           <ChatbotTranslation
             selectedChatId={selectedChatId}
             confirmedModelKey={confirmedModelKey}
+            createNewChat={createNewChat}
+            handleChatSelect={activateChat}
+            isPrivate={isPrivate}
           />
         )}
       </div>
@@ -117,7 +183,7 @@ function HomeChatbot() {
             selectedChatId={selectedChatId}
             chat_type={currTask}
             createNewChat={createNewChat}
-            onChatSelect={handleChatSelect}
+            onChatSelect={activateChat}
             handleForceUpdate={handleForceUpdate}
             forceUpdate={forceUpdate}
             setIsPrivate={setIsPrivate}

--- a/frontend/src/financeGPT/components/NavbarChatbot.js
+++ b/frontend/src/financeGPT/components/NavbarChatbot.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import fetcher from "../../http/RequestConfig";
 import ChatHistory from "./ChatHistory";
 import Modal from "../../components/Modal";
@@ -13,20 +13,11 @@ const TASK_TYPES = [
 
 function NavbarChatbot(props) {
   const [showConfirmPopup, setShowConfirmPopup] = useState(false);
-  const [showConfirmModelKey, setShowConfirmModelKey] = useState(false);
   const [showErrorKeyMessage, setShowErrorKeyMessage] = useState(false);
   const [showConfirmResetKey, setShowConfirmResetKey] = useState(false);
+  const [showConfirmModelSwitch, setShowConfirmModelSwitch] = useState(false);
   const [pendingTask, setPendingTask] = useState(null);
-  const [modelKey, setModelKey] = useState("");
-
-  useEffect(() => {
-    props.handleForceUpdate();
-  }, [props.isPrivate]);
-
-  useEffect(() => {
-    setModelKey(props.confirmedModelKey);
-    props.handleForceUpdate();
-  }, [props.confirmedModelKey]);
+  const [pendingModelType, setPendingModelType] = useState(null);
 
   const handleTaskChange = (taskId) => {
     if (taskId !== props.currTask) {
@@ -35,18 +26,12 @@ function NavbarChatbot(props) {
     }
   };
 
-  const confirmSwitchChange = () => {
-    props.setcurrTask(pendingTask);
-    changeChatMode(props.isPrivate);
+  const confirmSwitchChange = async () => {
+    if (pendingTask === null) return;
+
+    await props.createNewChat(pendingTask, props.isPrivate);
     setShowConfirmPopup(false);
     setPendingTask(null);
-  };
-
-  const confirmModelKey = () => {
-    resetChat();
-    props.setConfirmedModelKey(modelKey);
-    addModelKeyToDb(modelKey);
-    setShowConfirmModelKey(false);
   };
 
   const confirmResetModel = () => {
@@ -74,6 +59,37 @@ function NavbarChatbot(props) {
     props.handleForceUpdate();
   };
 
+  const handleModelChange = (value) => {
+    const nextModelType = value === "llama2" ? 0 : 1;
+
+    if (nextModelType === props.isPrivate) {
+      return;
+    }
+
+    if (props.selectedChatId === null) {
+      props.setIsPrivate(nextModelType);
+      return;
+    }
+
+    setPendingModelType(nextModelType);
+    setShowConfirmModelSwitch(true);
+  };
+
+  const confirmModelSwitch = async () => {
+    if (pendingModelType === null) return;
+
+    try {
+      await changeChatMode(pendingModelType);
+      props.setIsPrivate(pendingModelType);
+      props.handleForceUpdate();
+    } catch (e) {
+      console.error("Error switching model:", e);
+    } finally {
+      setPendingModelType(null);
+      setShowConfirmModelSwitch(false);
+    }
+  };
+
   const changeChatMode = async (isPrivate) => {
     try {
       await fetcher("change-chat-mode", {
@@ -92,20 +108,44 @@ function NavbarChatbot(props) {
       <Modal
         isOpen={showConfirmPopup}
         onClose={() => setShowConfirmPopup(false)}
-        title="Switch Mode?"
+        title="Switch Task?"
       >
         <p className="text-gray-300 mb-4">
-          Switching modes will reset your current chat. Are you sure?
+          Switching tasks will start a new chat so your current conversation stays intact.
         </p>
         <div className="flex space-x-3">
           <button
             onClick={confirmSwitchChange}
             className="flex-1 py-2 bg-gradient-to-r from-[#2E5C82] to-[#50B7C3] text-white rounded-lg font-semibold hover:opacity-90"
           >
-            Yes, switch
+            Start new chat
           </button>
           <button
             onClick={() => setShowConfirmPopup(false)}
+            className="flex-1 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+          >
+            Cancel
+          </button>
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={showConfirmModelSwitch}
+        onClose={() => setShowConfirmModelSwitch(false)}
+        title="Switch Local Model?"
+      >
+        <p className="text-gray-300 mb-4">
+          Changing the local model will reset the current chat history but keep the attached documents and ticker.
+        </p>
+        <div className="flex space-x-3">
+          <button
+            onClick={confirmModelSwitch}
+            className="flex-1 py-2 bg-gradient-to-r from-[#2E5C82] to-[#50B7C3] text-white rounded-lg font-semibold hover:opacity-90"
+          >
+            Switch model
+          </button>
+          <button
+            onClick={() => setShowConfirmModelSwitch(false)}
             className="flex-1 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
           >
             Cancel
@@ -207,7 +247,7 @@ function NavbarChatbot(props) {
               <span className="text-gray-300 text-sm font-medium">Local Model</span>
               <select
                 className="bg-[#1E2030] rounded-lg border border-gray-700 focus:ring-0 focus:border-[#50B7C3] text-white text-sm cursor-pointer px-2 py-1.5"
-                onChange={() => setShowConfirmPopup(true)}
+                onChange={(e) => handleModelChange(e.target.value)}
                 value={props.isPrivate === 0 ? "llama2" : "mistral"}
               >
                 <option value="llama2">LLaMA 2</option>

--- a/frontend/src/financeGPT/components/SidebarChatbot.js
+++ b/frontend/src/financeGPT/components/SidebarChatbot.js
@@ -11,6 +11,8 @@ function SidebarChatbot(props) {
   const [docToDeleteName, setDocToDeleteName] = useState(null);
   const [docToDeleteId, setDocToDeleteId] = useState(null);
 
+  // Documents are refreshed from the active chat context and explicit refresh triggers.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     retrieveDocs();
   }, [props.selectedChatId, props.forceUpdate]);

--- a/frontend/src/financeGPT/components/chatbot_subcomponents/ChatbotEdgar.js
+++ b/frontend/src/financeGPT/components/chatbot_subcomponents/ChatbotEdgar.js
@@ -31,6 +31,8 @@ const ChatbotEdgar = (props) => {
       ? `Hello! I can answer questions about **${ticker}** based on their 10-K filing. How can I help you?`
       : "Hello, I am your financial assistant. Enter a stock ticker above to get started.";
 
+  // The initial mount should render the current chat state once without re-running on each helper redefinition.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     handleLoadChat();
     setIsFirstMessageSent(false);
@@ -39,6 +41,8 @@ const ChatbotEdgar = (props) => {
     ]);
   }, []);
 
+  // EDGAR chat reloads are tied to chat selection changes plus explicit refreshes.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     handleLoadChat();
     setIsFirstMessageSent(false);
@@ -68,15 +72,15 @@ const ChatbotEdgar = (props) => {
   const handleTryMessage = (text, chat_id, isPrivate) => {
     if (!text.trim()) return;
     if (chat_id === null || chat_id === undefined) {
-      props.createNewChat().then((newChatId) => {
-        if (newChatId) handleSendMessage(text, newChatId, isPrivate);
+      props.createNewChat(props.chat_type, isPrivate, false).then((newChat) => {
+        if (newChat?.id) handleSendMessage(text, newChat.id, newChat);
       });
     } else {
-      handleSendMessage(text, chat_id, isPrivate);
+      handleSendMessage(text, chat_id);
     }
   };
 
-  const handleSendMessage = async (text, chat_id) => {
+  const handleSendMessage = async (text, chat_id, newChat = null) => {
     if (inputRef.current) {
       inputRef.current.value = "";
       inputRef.current.style.height = "auto";
@@ -112,11 +116,14 @@ const ChatbotEdgar = (props) => {
         )
       );
 
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
       handleLoadChat();
       scrollToBottom();
 
       if (!isFirstMessageSent) {
-        inferChatName(text, answer);
+        inferChatName(text, answer, chat_id);
         setIsFirstMessageSent(true);
       }
     } catch (e) {
@@ -127,15 +134,18 @@ const ChatbotEdgar = (props) => {
             : msg
         )
       );
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
     }
   };
 
-  const inferChatName = async (text, answer) => {
+  const inferChatName = async (text, answer, chatId = props.selectedChatId) => {
     try {
       const response = await fetcher("infer-chat-name", {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
-        body: JSON.stringify({ messages: text.concat(answer), chat_id: props.selectedChatId, model_type: props.isPrivate }),
+        body: JSON.stringify({ messages: text.concat(answer), chat_id: chatId, model_type: props.isPrivate }),
       });
       const response_data = await response.json();
       props.setCurrChatName(response_data.chat_name);
@@ -146,14 +156,18 @@ const ChatbotEdgar = (props) => {
   };
 
   const handleLoadChat = async () => {
+    setMessages([{ message: welcomeMessage(props.ticker), sentTime: "just now", direction: "incoming" }]);
+
+    if (props.selectedChatId === null || props.selectedChatId === undefined) {
+      return;
+    }
+
     try {
       const response = await fetcher("retrieve-messages-from-chat", {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
         body: JSON.stringify({ chat_id: props.selectedChatId, chat_type: props.chat_type }),
       });
-
-      setMessages([{ message: welcomeMessage(props.ticker), sentTime: "just now", direction: "incoming" }]);
 
       const response_data = await response.json();
       const transformedMessages = response_data.messages.map((item) => ({
@@ -162,7 +176,10 @@ const ChatbotEdgar = (props) => {
         relevant_chunks: item.relevant_chunks,
       }));
 
-      setMessages((prev) => [...prev, ...transformedMessages]);
+      setMessages([
+        { message: welcomeMessage(props.ticker), sentTime: "just now", direction: "incoming" },
+        ...transformedMessages,
+      ]);
       setIsFirstMessageSent(transformedMessages.length > 1);
     } catch (error) {
       console.error("Error loading chat messages:", error);

--- a/frontend/src/financeGPT/components/chatbot_subcomponents/ChatbotTranslation.js
+++ b/frontend/src/financeGPT/components/chatbot_subcomponents/ChatbotTranslation.js
@@ -3,7 +3,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faPaperPlane,
   faLanguage,
-  faRobot,
   faUser,
   faCopy,
   faCheck,
@@ -37,6 +36,11 @@ const LANGUAGES = [
   { code: "Ukrainian", label: "Ukrainian" },
 ];
 
+const WELCOME_MESSAGE = {
+  message: "Hello! I'm your AI translation assistant. Type text below and choose target languages to translate.",
+  direction: "incoming",
+};
+
 function CopyButton({ text }) {
   const [copied, setCopied] = useState(false);
   const handleCopy = () => {
@@ -59,13 +63,40 @@ const ChatbotTranslation = (props) => {
   const [sourceText, setSourceText] = useState("");
   const [targetLang, setTargetLang] = useState("Spanish");
   const [sourceLang, setSourceLang] = useState("English");
-  const [messages, setMessages] = useState([
-    {
-      message: "Hello! I'm your AI translation assistant. Type text below and choose target languages to translate.",
-      direction: "incoming",
-    },
-  ]);
+  const [messages, setMessages] = useState([WELCOME_MESSAGE]);
   const messagesEndRef = useRef(null);
+
+  React.useEffect(() => {
+    const loadTranslationHistory = async () => {
+      setMessages([WELCOME_MESSAGE]);
+
+      if (props.selectedChatId === null || props.selectedChatId === undefined) {
+        return;
+      }
+
+      try {
+        const response = await fetcher("retrieve-messages-from-chat", {
+          method: "POST",
+          headers: { Accept: "application/json", "Content-Type": "application/json" },
+          body: JSON.stringify({
+            chat_id: props.selectedChatId,
+            chat_type: 2,
+          }),
+        });
+        const data = await response.json();
+        const transformedMessages = data.messages.map((item) => ({
+          message: item.message_text,
+          direction: item.sent_from_user === 1 ? "outgoing" : "incoming",
+          translatedText: item.sent_from_user === 0 ? item.message_text : undefined,
+        }));
+        setMessages([WELCOME_MESSAGE, ...transformedMessages]);
+      } catch (error) {
+        console.error("Error loading translation history:", error);
+      }
+    };
+
+    loadTranslationHistory();
+  }, [props.selectedChatId]);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
@@ -73,6 +104,18 @@ const ChatbotTranslation = (props) => {
 
   const handleTranslate = async () => {
     if (!sourceText.trim()) return;
+
+    let chatId = props.selectedChatId;
+    let newChat = null;
+
+    if (chatId === null || chatId === undefined) {
+      newChat = await props.createNewChat(2, props.isPrivate, false);
+      chatId = newChat?.id;
+    }
+
+    if (chatId === null || chatId === undefined) {
+      return;
+    }
 
     const tempId = Date.now();
     setMessages((prev) => [
@@ -91,7 +134,7 @@ const ChatbotTranslation = (props) => {
           text: sourceText,
           source_language: sourceLang,
           target_language: targetLang,
-          chat_id: props.selectedChatId,
+          chat_id: chatId,
           model_key: props.confirmedModelKey,
         }),
       });
@@ -105,6 +148,11 @@ const ChatbotTranslation = (props) => {
             : msg
         )
       );
+
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
+
       scrollToBottom();
     } catch (e) {
       setMessages((prev) =>
@@ -114,6 +162,9 @@ const ChatbotTranslation = (props) => {
             : msg
         )
       );
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
     }
   };
 


### PR DESCRIPTION
## What changed
- unified active chat/session restoration in Home
- fixed task switching to create the correct chat type
- fixed local model switching and reset behavior
- restored translation history and auto-created translation chats
- added route fallback to avoid blank screens on unknown paths

## Why
Recent backend and UI work added translation persistence and shared chat abstractions, but the session state flow was still inconsistent across tasks and models. This PR makes the core chat experience predictable again.

## Validation
- npm test -- --watchAll=false
- npm run build