### PR TITLE
Codex/modernize local models

### DIFF
--- a/backend/api_endpoints/financeGPT/chatbot_endpoints.py
+++ b/backend/api_endpoints/financeGPT/chatbot_endpoints.py
@@ -2,12 +2,13 @@ import sqlite3
 import os
 import openai
 import numpy as np
+import ollama
 from sec_api import QueryApi, RenderApi
 import requests
 import PyPDF2
 import sys
-import concurrent.futures
 from dotenv import load_dotenv
+from local_models import LOCAL_EMBEDDING_MODEL, normalize_model_type
 
 load_dotenv()
 
@@ -39,8 +40,9 @@ def get_db_connection():
 # Chat_type is an integer where 0=chatbot, 1=Edgar, 2=PDFUploader, etc
 def add_chat_to_db(chat_type, model_type): #intake the current userID and the model type into the chat table
     conn, cursor = get_db_connection()
+    normalized_model_type = normalize_model_type(model_type)
 
-    cursor.execute('INSERT INTO chats (user_id, model_type, associated_task) VALUES (?, ?, ?)', (USER_ID, model_type, chat_type))
+    cursor.execute('INSERT INTO chats (user_id, model_type, associated_task) VALUES (?, ?, ?)', (USER_ID, normalized_model_type, chat_type))
     chat_id = cursor.lastrowid
 
     name = f"Chat {chat_id}"
@@ -225,6 +227,7 @@ def find_most_recent_chat_from_db():
 
 def change_chat_mode_db(chat_mode_to_change_to, chat_id):
     conn, cursor = get_db_connection()
+    normalized_model_type = normalize_model_type(chat_mode_to_change_to)
 
     query = """
     UPDATE chats
@@ -233,7 +236,7 @@ def change_chat_mode_db(chat_mode_to_change_to, chat_id):
     """
 
     # Execute the query
-    cursor.execute(query, (chat_mode_to_change_to, chat_id, USER_ID))
+    cursor.execute(query, (normalized_model_type, chat_id, USER_ID))
 
     conn.commit()
     conn.close()
@@ -261,21 +264,53 @@ def add_document_to_db(text, document_name, chat_id):
 
     return doc_id, False
 
-def _embed_chunk(args):
-    """Embed a single chunk — suitable for parallel execution."""
-    start_index, end_index, chunk_text = args
-    embedding = openai.embeddings.create(input=chunk_text, model="text-embedding-ada-002").data[0].embedding
-    vec = np.array(embedding)
-    return {
-        "text": chunk_text,
-        "start_index": start_index,
-        "end_index": end_index,
-        "embedding_vector_blob": vec.tobytes(),
-    }
+def _extract_embedding_list(response):
+    if isinstance(response, dict):
+        if "embeddings" in response:
+            return response["embeddings"]
+        if "embedding" in response:
+            return [response["embedding"]]
+
+    embeddings = getattr(response, "embeddings", None)
+    if embeddings is not None:
+        return embeddings
+
+    embedding = getattr(response, "embedding", None)
+    if embedding is not None:
+        return [embedding]
+
+    return []
+
+
+def generate_local_embeddings(inputs):
+    if not inputs:
+        return []
+
+    if hasattr(ollama, "embed"):
+        response = ollama.embed(model=LOCAL_EMBEDDING_MODEL, input=inputs)
+        vectors = [np.array(vector, dtype=np.float32) for vector in _extract_embedding_list(response)]
+        if len(vectors) != len(inputs):
+            raise RuntimeError(
+                f"Expected {len(inputs)} embeddings from {LOCAL_EMBEDDING_MODEL}, received {len(vectors)}."
+            )
+        return vectors
+
+    vectors = []
+    for item in inputs:
+        response = ollama.embeddings(model=LOCAL_EMBEDDING_MODEL, prompt=item)
+        extracted = _extract_embedding_list(response)
+        if extracted:
+            vectors.append(np.array(extracted[0], dtype=np.float32))
+
+    if len(vectors) != len(inputs):
+        raise RuntimeError(
+            f"Expected {len(inputs)} embeddings from {LOCAL_EMBEDDING_MODEL}, received {len(vectors)}."
+        )
+
+    return vectors
 
 def chunk_document(text, maxChunkSize, document_id):
-    """Chunk a document and embed all chunks in parallel for faster uploads."""
-    # Build raw chunk list first
+    """Chunk a document and embed all chunks locally with Ollama."""
     raw_chunks = []
     startIndex = 0
     while startIndex < len(text):
@@ -285,12 +320,25 @@ def chunk_document(text, maxChunkSize, document_id):
             raw_chunks.append((startIndex, endIndex, chunkText))
         startIndex += maxChunkSize
 
-    # Embed all chunks in parallel (up to 8 workers)
-    max_workers = min(8, len(raw_chunks)) if raw_chunks else 1
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-        embedded_chunks = list(executor.map(_embed_chunk, raw_chunks))
+    if not raw_chunks:
+        return
 
-    # Write all to DB in one transaction
+    embedded_vectors = generate_local_embeddings([chunk[2] for chunk in raw_chunks])
+    if len(embedded_vectors) != len(raw_chunks):
+        raise RuntimeError(
+            f"Expected {len(raw_chunks)} chunk embeddings from {LOCAL_EMBEDDING_MODEL}, received {len(embedded_vectors)}."
+        )
+
+    embedded_chunks = []
+    for (start_index, end_index, _chunk_text), vector in zip(raw_chunks, embedded_vectors):
+        embedded_chunks.append(
+            {
+                "start_index": start_index,
+                "end_index": end_index,
+                "embedding_vector_blob": vector.tobytes(),
+            }
+        )
+
     conn, cursor = get_db_connection()
     cursor.executemany(
         'INSERT INTO chunks (start_index, end_index, document_id, embedding_vector) VALUES (?,?,?,?)',
@@ -347,8 +395,11 @@ def get_relevant_chunks(k, question, chat_id):
 
     embeddings = np.array(embeddings)
 
-    embeddingVector = openai.embeddings.create(input=question, model="text-embedding-ada-002").data[0].embedding
-    embeddingVector = np.array(embeddingVector)
+    query_vectors = generate_local_embeddings([question])
+    if not query_vectors:
+        return []
+
+    embeddingVector = query_vectors[0]
 
     res = knn(embeddingVector, embeddings)
     num_results = min(k, len(res))

--- a/backend/app.py
+++ b/backend/app.py
@@ -11,6 +11,7 @@ import threading
 import re
 import PyPDF2
 import uuid
+import shutil
 
 
 from api_endpoints.financeGPT.chatbot_endpoints import add_chat_to_db, retrieve_chats_from_db, retrieve_message_from_db, retrieve_docs_from_db, delete_doc_from_db, \
@@ -18,6 +19,7 @@ from api_endpoints.financeGPT.chatbot_endpoints import add_chat_to_db, retrieve_
                                                         reset_chat_db, change_chat_mode_db, add_message_to_db, get_relevant_chunks, add_sources_to_db, add_model_key_to_db, \
                                                         check_valid_api, reset_uploaded_docs, add_ticker_to_chat_db, download_10K_url_ticker, download_filing_as_pdf, \
                                                         get_text_from_single_file, translate_text
+from local_models import DEFAULT_CHAT_MODEL_TYPE, LOCAL_EMBEDDING_MODEL, get_fallback_chat_models, get_local_chat_models, resolve_chat_model
 
 
 #load_dotenv()
@@ -34,8 +36,46 @@ config = {
 
 CORS(app, resources={r'/*': {'origins': '*'}}, supports_credentials=True)
 
-process_status_llama = {"running": False, "output": "", "error": ""}
-process_status_mistral = {"running": False, "output": "", "error": ""}
+
+def create_process_status():
+    return {"running": False, "output": "", "error": "", "completed": False, "progress": 0, "time_left": ""}
+
+
+process_status_by_model = {
+    model["id"]: create_process_status()
+    for model in get_local_chat_models()
+}
+
+
+def get_ollama_manifest_path(model_tag):
+    base_path = os.path.expanduser('~/.ollama/models/manifests/registry.ollama.ai/library')
+    model_name, variant = (model_tag.split(':', 1) + [None])[:2]
+    model_dir = os.path.join(base_path, model_name)
+    if variant is None:
+        return model_dir
+    return os.path.join(model_dir, variant)
+
+
+def is_model_installed(model_tag):
+    model_path = get_ollama_manifest_path(model_tag)
+    model_dir = os.path.dirname(model_path)
+    return os.path.exists(model_path) or os.path.isdir(model_dir)
+
+
+def serialize_model(model):
+    return {
+        **model,
+        "installed": is_model_installed(model["tag"]),
+    }
+
+
+def get_model_status(model_type):
+    model = resolve_chat_model(model_type)
+    return process_status_by_model[model["id"]]
+
+
+def get_ollama_binary():
+    return os.getenv("OLLAMA_PATH") or shutil.which("ollama") or '/usr/local/bin/ollama'
 
 @app.before_request
 def before_request():
@@ -66,116 +106,145 @@ def test_flask():
     return jsonify(test=test)
 
 #INSTALLATION
+@app.route('/local-models', methods=['POST'])
+@cross_origin(origins='*', supports_credentials=True)
+def local_models():
+    models = [serialize_model(model) for model in get_local_chat_models()]
+    return jsonify({
+        "models": models,
+        "default_model_type": DEFAULT_CHAT_MODEL_TYPE,
+        "embedding_model": LOCAL_EMBEDDING_MODEL,
+    })
+
+
 @app.route('/check-models', methods=['POST'])
 @cross_origin(origins='*', supports_credentials=True)
 def check_models():
-    base_path = os.path.expanduser('~/.ollama/models/manifests/registry.ollama.ai/library')
-    llama2_exists = os.path.isdir(os.path.join(base_path, 'llama2'))
-    mistral_exists = os.path.isdir(os.path.join(base_path, 'mistral'))
-    print("llama and mistral", llama2_exists, mistral_exists)
-    return jsonify({'llama2_exists': llama2_exists, 'mistral_exists': mistral_exists})
+    models = [serialize_model(model) for model in get_local_chat_models()]
+    return jsonify({
+        "models": models,
+        "default_model_type": DEFAULT_CHAT_MODEL_TYPE,
+        "embedding_model": LOCAL_EMBEDDING_MODEL,
+        # Legacy keys retained for backwards compatibility with older tests/UI.
+        "llama2_exists": models[0]["installed"] if len(models) > 0 else False,
+        "mistral_exists": models[1]["installed"] if len(models) > 1 else False,
+    })
 
-def run_llama_async():
-    ollama_path = '/usr/local/bin/ollama'
-    # For Windows
-    # ollama_path = os.path.join(os.getenv('LOCALAPPDATA'), 'Programs', 'Ollama', 'ollama.exe')
-    command = [ollama_path, 'run', 'llama2']
-    
+
+def run_model_pull_async(model):
+    ollama_path = get_ollama_binary()
+    command = [ollama_path, 'pull', model["tag"]]
+    process_status = process_status_by_model[model["id"]]
+
     # Regular expression to match the time left message format
     time_left_regex = re.compile(r'\b\d+m\d+s\b')
     progress_regex = re.compile(r'(\d+)%')
 
     try:
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-        
-        # Monitor the process output in real-time
-        for line in iter(process.stderr.readline, ''):
-            print(line, end='')  # Debug: print each line to server log
-            match = time_left_regex.search(line)
-            if match:
-                process_status_llama["time_left"] = match.group()
-                
-            match_progress = progress_regex.search(line)
-            if match_progress:
-                process_status_llama["progress"] = int(match_progress.group(1))
-        
-        process.wait()  # Wait for the process to complete
-        process_status_llama["running"] = False
-        process_status_llama["completed"] = True
-        process_status_llama["progress"] = 100
-        print("process complete")
-    except Exception as e:
-        process_status_llama["running"] = False
-        process_status_llama["completed"] = True
-        process_status_llama["error"] = str(e)
-        
-def run_mistral_async():
-    ollama_path = '/usr/local/bin/ollama'
-    # For Windows
-    # ollama_path = os.path.join(os.getenv('LOCALAPPDATA'), 'Programs', 'Ollama', 'ollama.exe')
-    command = [ollama_path, 'run', 'mistral']
-    
-    # Regular expression to match the time left message format
-    time_left_regex = re.compile(r'\b\d+m\d+s\b')
-    progress_regex = re.compile(r'(\d+)%')
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        output_lines = []
 
-    try:
-        process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-        # For Windows
-        # process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, shell=True)
-        
         # Monitor the process output in real-time
-        for line in iter(process.stderr.readline, ''):
+        for line in iter(process.stdout.readline, ''):
             print(line, end='')  # Debug: print each line to server log
+            output_lines.append(line.strip())
+            process_status["output"] = "\n".join(output_lines[-20:])
             match = time_left_regex.search(line)
             if match:
-                process_status_mistral["time_left"] = match.group()
-                
+                process_status["time_left"] = match.group()
+
             match_progress = progress_regex.search(line)
             if match_progress:
-                process_status_mistral["progress"] = int(match_progress.group(1))
-        
-        process.wait()  # Wait for the process to complete
-        print("process complete")
-        process_status_mistral["running"] = False
-        process_status_mistral["completed"] = True
-        process_status_mistral["progress"] = 100
+                process_status["progress"] = int(match_progress.group(1))
+
+        return_code = process.wait()  # Wait for the process to complete
+        process_status["running"] = False
+        process_status["completed"] = True
+        process_status["time_left"] = ""
+
+        if return_code == 0:
+            process_status["error"] = ""
+            process_status["progress"] = 100
+            print("process complete")
+        else:
+            process_status["error"] = process_status["output"] or f"Ollama exited with status {return_code}."
     except Exception as e:
-        process_status_mistral["running"] = False
-        process_status_mistral["completed"] = True
-        process_status_mistral["error"] = str(e)
-        
+        process_status["running"] = False
+        process_status["completed"] = True
+        process_status["time_left"] = ""
+        process_status["error"] = str(e)
+
+
+def start_model_install(model_type):
+    model = resolve_chat_model(model_type)
+    process_status = process_status_by_model[model["id"]]
+    serialized_model = serialize_model(model)
+
+    if process_status["running"]:
+        return jsonify({"success": False, "message": f"{model['label']} is already downloading."})
+
+    if serialized_model["installed"]:
+        process_status.update(create_process_status())
+        process_status["completed"] = True
+        process_status["progress"] = 100
+        return jsonify({
+            "success": True,
+            "already_installed": True,
+            "message": f"{model['label']} is already installed.",
+            "model": serialized_model,
+        })
+
+    process_status.update(create_process_status())
+    process_status["running"] = True
+    threading.Thread(target=run_model_pull_async, args=(model,), daemon=True).start()
+    return jsonify({"success": True, "message": f"{model['label']} pull initiated.", "model": serialized_model})
+
+
+def get_model_status_response(model_type):
+    model = resolve_chat_model(model_type)
+    return jsonify({**process_status_by_model[model["id"]], "model": serialize_model(model)})
 
 @app.route('/install-llama', methods=['POST'])
 @cross_origin(origins='*', supports_credentials=True)
 def run_llama():
-    if not process_status_llama["running"]:
-        process_status_llama["running"] = True
-        process_status_llama["completed"] = False
-        threading.Thread(target=run_llama_async, daemon=True).start()
-        return jsonify({"success": True, "message": "Ollama run initiated."})
-    else:
-        return jsonify({"success": False, "message": "Ollama run is already in progress."})
-        
+    return start_model_install(0)
+
 @app.route('/install-mistral', methods=['POST'])
 @cross_origin(origins='*', supports_credentials=True)
 def run_mistral():
-    if not process_status_mistral["running"]:
-        process_status_mistral["running"] = True
-        process_status_mistral["completed"] = False
-        threading.Thread(target=run_mistral_async, daemon=True).start()
-        return jsonify({"success": True, "message": "Mistral run initiated."})
-    else:
-        return jsonify({"success": False, "message": "Ollama run is already in progress."})
+    return start_model_install(1)
+
+
+@app.route('/install-local-model', methods=['POST'])
+@cross_origin(origins='*', supports_credentials=True)
+def install_local_model():
+    payload = request.get_json(silent=True) or {}
+    model_type = payload.get('model_type', DEFAULT_CHAT_MODEL_TYPE)
+    return start_model_install(model_type)
+
+
 @app.route('/llama-status', methods=['POST'])
 @cross_origin(origins='*', supports_credentials=True)
 def llama_status():
-    return jsonify(process_status_llama)
+    return get_model_status_response(0)
 
 @app.route('/mistral-status', methods=['POST'])
 @cross_origin(origins='*', supports_credentials=True)
 def mistral_status():
-    return jsonify(process_status_mistral)
+    return get_model_status_response(1)
+
+
+@app.route('/local-model-status', methods=['POST'])
+@cross_origin(origins='*', supports_credentials=True)
+def local_model_status():
+    payload = request.get_json(silent=True) or {}
+    model_type = payload.get('model_type', DEFAULT_CHAT_MODEL_TYPE)
+    return get_model_status_response(model_type)
 
 @app.route('/download-chat-history', methods=['POST'])
 @cross_origin(origins='*', supports_credentials=True)
@@ -376,24 +445,16 @@ def process_message_pdf():
             answer = response.choices[0].message.content.strip()
         except Exception as e:
             return jsonify({"error": f"OpenAI API error: {str(e)}"}), 500
-    elif model_type == 0:
-        try:
-            response = ollama.chat(model='llama2', messages=[
-                {'role': 'system', 'content': system_prompt},
-                {'role': 'user', 'content': user_prompt},
-            ])
-            answer = response['message']['content']
-        except Exception as e:
-            return jsonify({"error": "Error with llama2"}), 500
     else:
+        local_model = resolve_chat_model(model_type)
         try:
-            response = ollama.chat(model='mistral', messages=[
+            response = ollama.chat(model=local_model["tag"], messages=[
                 {'role': 'system', 'content': system_prompt},
                 {'role': 'user', 'content': user_prompt},
             ])
             answer = response['message']['content']
         except Exception as e:
-            return jsonify({"error": "Error with Mistral"}), 500
+            return jsonify({"error": f"Error with {local_model['label']}"}), 500
 
     #This adds bot message
     message_id = add_message_to_db(answer, chat_id, 0)
@@ -470,15 +531,15 @@ def process_ticker_info():
 def infer_chat_name():
     messages = request.json.get('messages', '')
     chat_id = request.json.get('chat_id')
-    model_type = request.json.get('model_type', 1)  # 0=llama2, 1=mistral
+    model_type = request.json.get('model_type', DEFAULT_CHAT_MODEL_TYPE)
 
     prompt_msg = [{
         'role': 'user',
         'content': f'Generate a short 3-5 word chat title for this conversation snippet. Reply with only the title, no punctuation or quotes:\n\n{messages[:500]}'
     }]
 
-    # Try preferred model first, then the other, then word-truncation fallback
-    models_to_try = ['mistral', 'llama2'] if model_type == 1 else ['llama2', 'mistral']
+    # Try preferred model first, then the remaining local models, then word-truncation fallback
+    models_to_try = [model["tag"] for model in get_fallback_chat_models(model_type)]
     chat_name = None
 
     for model in models_to_try:

--- a/backend/local_models.py
+++ b/backend/local_models.py
@@ -1,0 +1,53 @@
+import os
+
+
+LOCAL_CHAT_MODELS = [
+    {
+        "id": 0,
+        "key": "qwen3_8b",
+        "tag": "qwen3:8b",
+        "label": "Qwen 3 8B",
+        "description": "Recommended default for local document Q&A.",
+    },
+    {
+        "id": 1,
+        "key": "llama3_1_8b",
+        "tag": "llama3.1:8b",
+        "label": "Llama 3.1 8B",
+        "description": "Strong general-purpose local model with broad ecosystem support.",
+    },
+]
+
+DEFAULT_CHAT_MODEL_TYPE = int(os.getenv("DEFAULT_LOCAL_CHAT_MODEL_TYPE", "0"))
+LOCAL_EMBEDDING_MODEL = os.getenv("OLLAMA_EMBEDDING_MODEL", "embeddinggemma")
+
+
+def get_local_chat_models():
+    return [dict(model) for model in LOCAL_CHAT_MODELS]
+
+
+def normalize_model_type(model_type):
+    try:
+        candidate = int(model_type)
+    except (TypeError, ValueError):
+        candidate = DEFAULT_CHAT_MODEL_TYPE
+
+    for model in LOCAL_CHAT_MODELS:
+        if model["id"] == candidate:
+            return candidate
+
+    return DEFAULT_CHAT_MODEL_TYPE
+
+
+def resolve_chat_model(model_type):
+    normalized_type = normalize_model_type(model_type)
+    for model in LOCAL_CHAT_MODELS:
+        if model["id"] == normalized_type:
+            return dict(model)
+    return dict(LOCAL_CHAT_MODELS[0])
+
+
+def get_fallback_chat_models(model_type):
+    preferred = resolve_chat_model(model_type)
+    fallbacks = [dict(model) for model in LOCAL_CHAT_MODELS if model["id"] != preferred["id"]]
+    return [preferred, *fallbacks]

--- a/backend/tests/test_documents.py
+++ b/backend/tests/test_documents.py
@@ -153,7 +153,7 @@ class TestProcessMessagePdf:
             "model_key": model_key,
         }
 
-    def test_llama2_response(self, client):
+    def test_primary_local_model_response(self, client):
         mock_ollama_resp = {"message": {"content": "Revenue was $5B."}}
         with patch(
             "api_endpoints.financeGPT.chatbot_endpoints.get_relevant_chunks",
@@ -163,12 +163,13 @@ class TestProcessMessagePdf:
             return_value=1,
         ), patch(
             "api_endpoints.financeGPT.chatbot_endpoints.add_sources_to_db"
-        ), patch("ollama.chat", return_value=mock_ollama_resp):
+        ), patch("ollama.chat", return_value=mock_ollama_resp) as mock_chat:
             resp = _post(client, "/process-message-pdf", self._payload(model_type=0))
         assert resp.status_code == 200
         assert resp.get_json()["answer"] == "Revenue was $5B."
+        assert mock_chat.call_args.kwargs["model"] == "qwen3:8b"
 
-    def test_mistral_response(self, client):
+    def test_secondary_local_model_response(self, client):
         mock_ollama_resp = {"message": {"content": "Net income was $1.2B."}}
         with patch(
             "api_endpoints.financeGPT.chatbot_endpoints.get_relevant_chunks",
@@ -178,12 +179,13 @@ class TestProcessMessagePdf:
             return_value=2,
         ), patch(
             "api_endpoints.financeGPT.chatbot_endpoints.add_sources_to_db"
-        ), patch("ollama.chat", return_value=mock_ollama_resp):
+        ), patch("ollama.chat", return_value=mock_ollama_resp) as mock_chat:
             resp = _post(client, "/process-message-pdf", self._payload(model_type=1))
         assert resp.status_code == 200
         assert "1.2B" in resp.get_json()["answer"]
+        assert mock_chat.call_args.kwargs["model"] == "llama3.1:8b"
 
-    def test_llama2_failure_returns_500(self, client):
+    def test_local_model_failure_returns_500(self, client):
         with patch(
             "api_endpoints.financeGPT.chatbot_endpoints.get_relevant_chunks",
             return_value=[],
@@ -193,3 +195,4 @@ class TestProcessMessagePdf:
         ), patch("ollama.chat", side_effect=Exception("model not found")):
             resp = _post(client, "/process-message-pdf", self._payload(model_type=0))
         assert resp.status_code == 500
+        assert "Qwen 3 8B" in resp.get_json()["error"]

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,6 +1,9 @@
 """
 Tests for model management endpoints:
   POST /check-models
+  POST /local-models
+  POST /install-local-model
+  POST /local-model-status
   POST /install-llama
   POST /install-mistral
   POST /llama-status
@@ -21,13 +24,28 @@ def _post(client, url, payload=None):
     )
 
 
+@pytest.fixture(autouse=True)
+def reset_model_install_state():
+    from app import create_process_status, process_status_by_model
+
+    for model_id in list(process_status_by_model.keys()):
+        process_status_by_model[model_id].clear()
+        process_status_by_model[model_id].update(create_process_status())
+
+    yield
+
+    for model_id in list(process_status_by_model.keys()):
+        process_status_by_model[model_id].clear()
+        process_status_by_model[model_id].update(create_process_status())
+
+
 # ---------------------------------------------------------------------------
 # /check-models
 # ---------------------------------------------------------------------------
 
 class TestCheckModels:
     def test_both_models_present(self, client):
-        with patch("os.path.isdir", return_value=True):
+        with patch("app.is_model_installed", return_value=True):
             resp = _post(client, "/check-models")
         assert resp.status_code == 200
         data = resp.get_json()
@@ -35,12 +53,25 @@ class TestCheckModels:
         assert data["mistral_exists"] is True
 
     def test_no_models_installed(self, client):
-        with patch("os.path.isdir", return_value=False):
+        with patch("app.is_model_installed", return_value=False):
             resp = _post(client, "/check-models")
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["llama2_exists"] is False
         assert data["mistral_exists"] is False
+
+
+class TestLocalModels:
+    def test_returns_local_model_registry(self, client):
+        with patch("app.is_model_installed", return_value=False):
+            resp = _post(client, "/local-models")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["default_model_type"] == 0
+        assert len(data["models"]) >= 2
+        assert data["models"][0]["tag"] == "qwen3:8b"
+        assert data["models"][1]["tag"] == "llama3.1:8b"
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +80,7 @@ class TestCheckModels:
 
 class TestInstallLlama:
     def test_install_initiates_successfully(self, client):
-        with patch("threading.Thread") as mock_thread:
+        with patch("app.threading.Thread") as mock_thread:
             mock_thread.return_value.start = MagicMock()
             resp = _post(client, "/install-llama")
         assert resp.status_code == 200
@@ -57,7 +88,7 @@ class TestInstallLlama:
         assert data.get("success") is True
 
     def test_install_returns_json(self, client):
-        with patch("threading.Thread") as mock_thread:
+        with patch("app.threading.Thread") as mock_thread:
             mock_thread.return_value.start = MagicMock()
             resp = _post(client, "/install-llama")
         assert resp.content_type == "application/json"
@@ -69,11 +100,32 @@ class TestInstallLlama:
 
 class TestInstallMistral:
     def test_install_initiates_successfully(self, client):
-        with patch("threading.Thread") as mock_thread:
+        with patch("app.threading.Thread") as mock_thread:
             mock_thread.return_value.start = MagicMock()
             resp = _post(client, "/install-mistral")
         assert resp.status_code == 200
         assert resp.get_json().get("success") is True
+
+
+class TestInstallLocalModel:
+    def test_install_selected_model(self, client):
+        with patch("app.threading.Thread") as mock_thread:
+            mock_thread.return_value.start = MagicMock()
+            resp = _post(client, "/install-local-model", {"model_type": 1})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["model"]["tag"] == "llama3.1:8b"
+
+    def test_install_reports_already_installed(self, client):
+        with patch("app.is_model_installed", return_value=True):
+            resp = _post(client, "/install-local-model", {"model_type": 0})
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["already_installed"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +156,15 @@ class TestMistralStatus:
         resp = _post(client, "/mistral-status")
         assert resp.status_code == 200
         assert "running" in resp.get_json()
+
+
+class TestLocalModelStatus:
+    def test_status_for_selected_model(self, client):
+        resp = _post(client, "/local-model-status", {"model_type": 1})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "running" in data
+        assert data["model"]["tag"] == "llama3.1:8b"
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { BrowserRouter as Router, Navigate, Route, Routes } from "react-router-dom";
 import HomeChatbot from "./financeGPT/components/Home.js";
 
 function App() {
@@ -7,6 +7,7 @@ function App() {
     <Router>
       <Routes>
         <Route path="/" element={<HomeChatbot />} />
+        <Route path="*" element={<Navigate replace to="/" />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/financeGPT/components/ChatHistory.js
+++ b/frontend/src/financeGPT/components/ChatHistory.js
@@ -12,6 +12,8 @@ function ChatHistory(props) {
   const [chatIdToRename, setChatIdToRename] = useState(null);
   const [newChatName, setNewChatName] = useState("");
 
+  // This list refreshes only when the selected chat changes or callers force a reload.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     retrieveAllChats();
   }, [props.selectedChatId, props.forceUpdate]);
@@ -24,7 +26,6 @@ function ChatHistory(props) {
   const confirmDeleteChat = () => {
     deleteChat(chatToDelete);
     setShowConfirmPopupChat(false);
-    props.onChatSelect(null);
   };
 
   const handleRenameChat = (chat_id) => {
@@ -46,7 +47,7 @@ function ChatHistory(props) {
         body: JSON.stringify({ chat_type: props.chat_type }),
       });
       const response_data = await response.json();
-      setChats(response_data.chat_info);
+      setChats(response_data.chat_info || []);
     } catch (error) {
       console.error("Error fetching chats:", error);
     }
@@ -62,14 +63,22 @@ function ChatHistory(props) {
       if (response.ok) {
         props.handleForceUpdate();
         try {
-          const recentRes = await fetcher("find-most-recent-chat", {
+          const chatsRes = await fetcher("retrieve-all-chats", {
             method: "POST",
             headers: { Accept: "application/json", "Content-Type": "application/json" },
             body: JSON.stringify({}),
           });
-          const recentData = await recentRes.json();
-          props.handleChatSelect(recentData.chat_info.id);
-          props.setCurrChatName(recentData.chat_info.chat_name);
+          const chatsData = await chatsRes.json();
+          const updatedChats = chatsData.chat_info || [];
+          setChats(updatedChats);
+
+          if (updatedChats.length === 0) {
+            props.onChatSelect(null);
+            return;
+          }
+
+          const mostRecentChat = [...updatedChats].sort((a, b) => b.id - a.id)[0];
+          props.onChatSelect(mostRecentChat);
         } catch (e) {
           console.error("Error finding recent chat after deletion", e);
         }
@@ -80,12 +89,21 @@ function ChatHistory(props) {
   };
 
   const renameChat = async (chat_id, new_name) => {
+    const trimmedName = new_name.trim();
+
+    if (!trimmedName) {
+      return;
+    }
+
     try {
       await fetcher("update-chat-name", {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
-        body: JSON.stringify({ chat_id, chat_name: new_name }),
+        body: JSON.stringify({ chat_id, chat_name: trimmedName }),
       });
+      if (chat_id === props.selectedChatId) {
+        props.setCurrChatName(trimmedName);
+      }
       retrieveAllChats();
     } catch (e) {
       console.error("Error renaming chat:", e);
@@ -161,15 +179,8 @@ function ChatHistory(props) {
           onClick={() => {
             props
               .createNewChat()
-              .then((newChatId) => {
-                const chat_name = "Chat " + newChatId;
-                props.setIsPrivate(0);
-                props.setCurrChatName(chat_name);
-                props.setTicker("");
-                props.setShowChatbot(false);
-                props.onChatSelect(newChatId);
+              .then(() => {
                 props.handleForceUpdate();
-                props.setConfirmedModelKey("");
               })
               .catch((error) => console.error("Error creating new chat:", error));
           }}
@@ -187,15 +198,7 @@ function ChatHistory(props) {
           <div
             key={chat.id}
             onClick={() => {
-              props.onChatSelect(chat.id);
-              props.setIsPrivate(chat.model_type);
-              props.setTicker(chat.ticker);
-              if (chat.ticker) {
-                props.setIsEdit(0);
-                props.setShowChatbot(true);
-              }
-              props.setcurrTask(chat.associated_task);
-              props.setCurrChatName(chat.chat_name);
+              props.onChatSelect(chat);
             }}
             className={`flex items-center justify-between px-2 py-2 rounded-lg cursor-pointer transition-colors group ${
               props.selectedChatId === chat.id

--- a/frontend/src/financeGPT/components/Chatbot.js
+++ b/frontend/src/financeGPT/components/Chatbot.js
@@ -25,19 +25,14 @@ const Chatbot = (props) => {
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = React.useState(0);
   const [timeLeft, setTimeLeft] = React.useState("");
+  const welcomeMessage = {
+    message: "Hello, I am your financial assistant, how can I help you?",
+    sentTime: "just now",
+    direction: "incoming",
+  };
 
-  useEffect(() => {
-    loadLatestChat();
-    handleLoadChat();
-    setMessages([
-      {
-        message: "Hello, I am your financial assistant, how can I help you?",
-        sentTime: "just now",
-        direction: "incoming",
-      },
-    ]);
-  }, []);
-
+  // Chat history reloads are intentionally driven by chat selection plus explicit refreshes.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     handleLoadChat();
   }, [props.selectedChatId, props.forceUpdate]);
@@ -47,24 +42,6 @@ const Chatbot = (props) => {
       behavior: "smooth",
       block: "end",
     });
-  };
-
-  const loadLatestChat = async () => {
-    try {
-      const response = await fetcher("find-most-recent-chat", {
-        method: "POST",
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({}),
-      });
-      const response_data = await response.json();
-      props.handleChatSelect(response_data.chat_info.id);
-      props.setCurrChatName(response_data.chat_info.chat_name);
-    } catch (e) {
-      console.error("Error loading latest chat", e);
-    }
   };
 
   const handleDownload = async () => {
@@ -95,15 +72,15 @@ const Chatbot = (props) => {
   const handleTryMessage = (text, chat_id, isPrivate) => {
     if (!text.trim()) return;
     if (chat_id === null || chat_id === undefined) {
-      props.createNewChat().then((newChatId) => {
-        if (newChatId) handleSendMessage(text, newChatId, isPrivate);
+      props.createNewChat(props.chat_type, isPrivate, false).then((newChat) => {
+        if (newChat?.id) handleSendMessage(text, newChat.id, newChat);
       });
     } else {
-      handleSendMessage(text, chat_id, isPrivate);
+      handleSendMessage(text, chat_id);
     }
   };
 
-  const handleSendMessage = async (text, chat_id) => {
+  const handleSendMessage = async (text, chat_id, newChat = null) => {
     if (inputRef.current) {
       inputRef.current.value = "";
       inputRef.current.style.height = "auto";
@@ -141,6 +118,9 @@ const Chatbot = (props) => {
             : msg
         )
       );
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
       handleLoadChat();
       scrollToBottom();
     } catch (e) {
@@ -151,6 +131,9 @@ const Chatbot = (props) => {
             : msg
         )
       );
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
       setShowInstallationModal(true);
     }
   };
@@ -200,6 +183,12 @@ const Chatbot = (props) => {
   };
 
   const handleLoadChat = async () => {
+    setMessages([welcomeMessage]);
+
+    if (props.selectedChatId === null || props.selectedChatId === undefined) {
+      return;
+    }
+
     try {
       const response = await fetcher("retrieve-messages-from-chat", {
         method: "POST",
@@ -213,39 +202,35 @@ const Chatbot = (props) => {
         }),
       });
 
-      setMessages([
-        {
-          message: "Hello, I am your financial assistant, how can I help you?",
-          sentTime: "just now",
-          direction: "incoming",
-        },
-      ]);
-
       const response_data = await response.json();
       const transformedMessages = response_data.messages.map((item) => ({
         message: item.message_text,
         direction: item.sent_from_user === 1 ? "outgoing" : "incoming",
         relevant_chunks: item.relevant_chunks,
       }));
-      setMessages((prev) => [...prev, ...transformedMessages]);
+      setMessages([welcomeMessage, ...transformedMessages]);
     } catch (error) {
       console.error("Error loading chat messages:", error);
     }
   };
 
   const handleReset = async () => {
+    if (props.selectedChatId === null || props.selectedChatId === undefined) {
+      setMessages([welcomeMessage]);
+      return;
+    }
+
     try {
-      await fetcher("reset-everything", { method: "POST" });
+      await fetcher("reset-chat", {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: props.selectedChatId }),
+      });
+      props.handleForceUpdate();
     } catch (e) {
       console.error("Failed to reset:", e);
     }
-    setMessages([
-      {
-        message: "Hello, I am your financial assistant, how can I help you?",
-        sentTime: "just now",
-        direction: "incoming",
-      },
-    ]);
+    setMessages([welcomeMessage]);
   };
 
   const handleTextareaInput = (e) => {

--- a/frontend/src/financeGPT/components/Chatbot.js
+++ b/frontend/src/financeGPT/components/Chatbot.js
@@ -25,11 +25,21 @@ const Chatbot = (props) => {
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = React.useState(0);
   const [timeLeft, setTimeLeft] = React.useState("");
+  const [installError, setInstallError] = useState("");
+  const installPollTimeoutRef = useRef(null);
   const welcomeMessage = {
     message: "Hello, I am your financial assistant, how can I help you?",
     sentTime: "just now",
     direction: "incoming",
   };
+
+  useEffect(() => {
+    return () => {
+      if (installPollTimeoutRef.current) {
+        clearTimeout(installPollTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // Chat history reloads are intentionally driven by chat selection plus explicit refreshes.
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -134,51 +144,83 @@ const Chatbot = (props) => {
       if (newChat) {
         props.handleChatSelect(newChat);
       }
+      setInstallError("");
       setShowInstallationModal(true);
+    }
+  };
+
+  const resetInstallState = ({ keepModalOpen = false } = {}) => {
+    setIsLoading(false);
+    setProgress(0);
+    setTimeLeft("");
+    if (!keepModalOpen) {
+      setShowInstallationModal(false);
+    }
+    if (installPollTimeoutRef.current) {
+      clearTimeout(installPollTimeoutRef.current);
+      installPollTimeoutRef.current = null;
     }
   };
 
   const pollOllamaStatus = async () => {
     try {
-      const endpoint = props.isPrivate === 0 ? "/llama-status" : "/mistral-status";
-      const response = await fetcher(endpoint, { method: "POST" });
+      const response = await fetcher("local-model-status", {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ model_type: props.isPrivate }),
+      });
       const status = await response.json();
 
-      if (status.progress === 100 || (!status.running && status.completed)) {
-        setIsLoading(false);
-        setShowInstallationModal(false);
-        setProgress(0);
-        setTimeLeft("");
+      if (status.error) {
+        setInstallError(status.error);
+        resetInstallState({ keepModalOpen: true });
+        return;
+      }
+
+      if (status.model?.installed || status.progress === 100 || (!status.running && status.completed)) {
+        setInstallError("");
+        resetInstallState();
+        props.refreshLocalModels?.();
       } else {
         setTimeLeft(status.time_left || "Calculating...");
         setProgress(status.progress || 0);
-        setTimeout(pollOllamaStatus, 3000);
+        installPollTimeoutRef.current = setTimeout(pollOllamaStatus, 3000);
       }
     } catch (error) {
       console.error("Failed to fetch install status:", error);
-      setIsLoading(false);
-      setTimeLeft("");
-      setShowInstallationModal(false);
+      setInstallError("Unable to check installation progress. Please verify Ollama is running.");
+      resetInstallState({ keepModalOpen: true });
     }
   };
 
   const installDependencies = async () => {
+    setInstallError("");
+    setProgress(0);
+    setTimeLeft("Preparing download...");
     setIsLoading(true);
-    pollOllamaStatus();
     try {
-      const endpoint = props.isPrivate === 0 ? "/install-llama" : "/install-mistral";
-      const response = await fetcher(endpoint, {
+      const response = await fetcher("install-local-model", {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ model_type: props.isPrivate }),
       });
       const responseData = await response.json();
-      if (!responseData.success) {
-        console.error(responseData.message);
-        setIsLoading(false);
+      if (responseData.already_installed) {
+        setInstallError("");
+        resetInstallState();
+        props.refreshLocalModels?.();
+        return;
       }
+      if (!responseData.success) {
+        setInstallError(responseData.message || "Failed to start the local model download.");
+        resetInstallState({ keepModalOpen: true });
+        return;
+      }
+      pollOllamaStatus();
     } catch (error) {
       console.error("Installation failed:", error);
-      setIsLoading(false);
+      setInstallError("Installation failed. Please make sure Ollama is installed, then try again.");
+      resetInstallState({ keepModalOpen: true });
     }
   };
 
@@ -245,14 +287,14 @@ const Chatbot = (props) => {
     }
   };
 
-  const modelName = props.isPrivate === 0 ? "LLaMA 2" : "Mistral";
+  const selectedModelName = props.selectedLocalModel?.label || "Selected Model";
 
   return (
     <>
       <Modal
         isOpen={showInstallationModal}
         onClose={() => setShowInstallationModal(false)}
-        title={isLoading ? "Installing Model..." : `Install ${modelName}`}
+        title={isLoading ? "Installing Model..." : `Install ${selectedModelName}`}
       >
         {isLoading ? (
           <div className="w-full">
@@ -265,8 +307,8 @@ const Chatbot = (props) => {
             <p className="text-sm text-gray-400">{timeLeft || "Downloading..."}</p>
           </div>
         ) : (
-          <p className="text-gray-300 mb-4">
-            You have not installed {modelName}. Please install it to use local inference.
+          <p className={`mb-4 ${installError ? "text-red-400" : "text-gray-300"}`}>
+            {installError || `You have not installed ${selectedModelName}. Please install it to use local inference.`}
           </p>
         )}
         <button
@@ -278,7 +320,7 @@ const Chatbot = (props) => {
               : "bg-gradient-to-r from-[#2E5C82] to-[#50B7C3] text-white hover:opacity-90"
           }`}
         >
-          {isLoading ? "Installing..." : `Download ${modelName}`}
+          {isLoading ? "Installing..." : `Download ${selectedModelName}`}
         </button>
       </Modal>
 

--- a/frontend/src/financeGPT/components/Home.js
+++ b/frontend/src/financeGPT/components/Home.js
@@ -7,6 +7,46 @@ import fetcher from "../../http/RequestConfig";
 import ChatbotEdgar from "./chatbot_subcomponents/ChatbotEdgar";
 import ChatbotTranslation from "./chatbot_subcomponents/ChatbotTranslation";
 
+const FALLBACK_LOCAL_MODELS = [
+  {
+    id: 0,
+    key: "qwen3_8b",
+    tag: "qwen3:8b",
+    label: "Qwen 3 8B",
+    description: "Recommended default for local document Q&A.",
+    installed: false,
+  },
+  {
+    id: 1,
+    key: "llama3_1_8b",
+    tag: "llama3.1:8b",
+    label: "Llama 3.1 8B",
+    description: "Strong general-purpose local model with broad ecosystem support.",
+    installed: false,
+  },
+];
+
+async function requestLocalModels() {
+  try {
+    const response = await fetcher("local-models", {
+      method: "POST",
+      headers: { Accept: "application/json", "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    const responseData = await response.json();
+    return {
+      models: responseData.models?.length ? responseData.models : FALLBACK_LOCAL_MODELS,
+      defaultModelType: responseData.default_model_type ?? 0,
+    };
+  } catch (error) {
+    console.error("Error loading local models:", error);
+    return {
+      models: FALLBACK_LOCAL_MODELS,
+      defaultModelType: 0,
+    };
+  }
+}
+
 function HomeChatbot() {
   const [selectedChatId, setSelectedChatId] = useState(null);
   const [forceUpdate, setForceUpdate] = useState(0);
@@ -19,6 +59,7 @@ function HomeChatbot() {
   const [activeMessageIndex, setActiveMessageIndex] = useState(null);
   const [relevantChunk, setRelevantChunk] = useState("");
   const [confirmedModelKey, setConfirmedModelKey] = useState("");
+  const [localModels, setLocalModels] = useState(FALLBACK_LOCAL_MODELS);
 
   const activateChat = (chatSummary) => {
     if (!chatSummary) {
@@ -49,29 +90,55 @@ function HomeChatbot() {
     setForceUpdate((prev) => prev + 1);
   };
 
+  const refreshLocalModels = async () => {
+    const localModelState = await requestLocalModels();
+    setLocalModels(localModelState.models);
+    return localModelState;
+  };
+
   useEffect(() => {
-    const loadMostRecentChat = async () => {
-      try {
-        const response = await fetcher("retrieve-all-chats", {
+    let isMounted = true;
+
+    const loadInitialState = async () => {
+      const [localModelState, chats] = await Promise.all([
+        requestLocalModels(),
+        fetcher("retrieve-all-chats", {
           method: "POST",
           headers: { Accept: "application/json", "Content-Type": "application/json" },
           body: JSON.stringify({}),
-        });
-        const responseData = await response.json();
-        const chats = responseData.chat_info || [];
+        })
+          .then((response) => response.json())
+          .then((responseData) => responseData.chat_info || [])
+          .catch((error) => {
+            console.error("Error loading most recent chat:", error);
+            return [];
+          }),
+      ]);
 
-        if (chats.length === 0) {
-          return;
-        }
+      if (!isMounted) {
+        return;
+      }
 
+      setLocalModels(localModelState.models);
+
+      if (chats.length > 0) {
         const mostRecentChat = [...chats].sort((a, b) => b.id - a.id)[0];
         activateChat(mostRecentChat);
-      } catch (error) {
-        console.error("Error loading most recent chat:", error);
+        return;
       }
+
+      setIsPrivate((currentModelType) =>
+        localModelState.models.some((model) => model.id === currentModelType)
+          ? currentModelType
+          : localModelState.defaultModelType
+      );
     };
 
-    loadMostRecentChat();
+    loadInitialState();
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   const createNewChat = async (
@@ -106,6 +173,12 @@ function HomeChatbot() {
     }
   };
 
+  const selectedLocalModel =
+    localModels.find((model) => model.id === isPrivate) ||
+    FALLBACK_LOCAL_MODELS.find((model) => model.id === isPrivate) ||
+    localModels[0] ||
+    FALLBACK_LOCAL_MODELS[0];
+
   const sharedChatbotProps = {
     selectedChatId,
     handleChatSelect: activateChat,
@@ -119,6 +192,9 @@ function HomeChatbot() {
     setActiveMessageIndex,
     setRelevantChunk,
     createNewChat,
+    localModels,
+    selectedLocalModel,
+    refreshLocalModels,
   };
 
   return (
@@ -142,6 +218,9 @@ function HomeChatbot() {
           createNewChat={createNewChat}
           handleChatSelect={activateChat}
           forceUpdate={forceUpdate}
+          localModels={localModels}
+          selectedLocalModel={selectedLocalModel}
+          refreshLocalModels={refreshLocalModels}
         />
       </div>
 
@@ -172,6 +251,7 @@ function HomeChatbot() {
             createNewChat={createNewChat}
             handleChatSelect={activateChat}
             isPrivate={isPrivate}
+            selectedLocalModel={selectedLocalModel}
           />
         )}
       </div>

--- a/frontend/src/financeGPT/components/Home.js
+++ b/frontend/src/financeGPT/components/Home.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Navbarchatbot from "./NavbarChatbot";
 import Chatbot from "./Chatbot";
 import "../styles/Chatbot.css";
@@ -20,32 +20,95 @@ function HomeChatbot() {
   const [relevantChunk, setRelevantChunk] = useState("");
   const [confirmedModelKey, setConfirmedModelKey] = useState("");
 
-  const handleChatSelect = (chatId) => {
-    setSelectedChatId(chatId);
+  const activateChat = (chatSummary) => {
+    if (!chatSummary) {
+      setSelectedChatId(null);
+      setCurrChatName("");
+      setTicker("");
+      setShowChatbot(false);
+      setIsEdit(0);
+      setConfirmedModelKey("");
+      setActiveMessageIndex(null);
+      setRelevantChunk("");
+      return;
+    }
+
+    setSelectedChatId(chatSummary.id);
+    setIsPrivate(chatSummary.model_type ?? 0);
+    setCurrChatName(chatSummary.chat_name || `Chat ${chatSummary.id}`);
+    setcurrTask(chatSummary.associated_task ?? 0);
+    setTicker(chatSummary.ticker || "");
+    setShowChatbot(chatSummary.associated_task === 1 && Boolean(chatSummary.ticker));
+    setIsEdit(0);
+    setConfirmedModelKey(chatSummary.custom_model_key || "");
+    setActiveMessageIndex(null);
+    setRelevantChunk("");
   };
 
   const handleForceUpdate = () => {
     setForceUpdate((prev) => prev + 1);
   };
 
-  const createNewChat = async () => {
+  useEffect(() => {
+    const loadMostRecentChat = async () => {
+      try {
+        const response = await fetcher("retrieve-all-chats", {
+          method: "POST",
+          headers: { Accept: "application/json", "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        });
+        const responseData = await response.json();
+        const chats = responseData.chat_info || [];
+
+        if (chats.length === 0) {
+          return;
+        }
+
+        const mostRecentChat = [...chats].sort((a, b) => b.id - a.id)[0];
+        activateChat(mostRecentChat);
+      } catch (error) {
+        console.error("Error loading most recent chat:", error);
+      }
+    };
+
+    loadMostRecentChat();
+  }, []);
+
+  const createNewChat = async (
+    taskOverride = currTask,
+    modelOverride = isPrivate,
+    activateSelection = true
+  ) => {
     try {
       const response = await fetcher("create-new-chat", {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
-        body: JSON.stringify({ chat_type: currTask, model_type: isPrivate }),
+        body: JSON.stringify({ chat_type: taskOverride, model_type: modelOverride }),
       });
-      const response_data = await response.json();
-      handleChatSelect(response_data.chat_id);
-      return response_data.chat_id;
+      const responseData = await response.json();
+      const chatSummary = {
+        id: responseData.chat_id,
+        chat_name: `Chat ${responseData.chat_id}`,
+        associated_task: taskOverride,
+        model_type: modelOverride,
+        ticker: "",
+        custom_model_key: "",
+      };
+
+      if (activateSelection) {
+        activateChat(chatSummary);
+      }
+
+      return chatSummary;
     } catch (e) {
       console.error("Error creating new chat:", e);
+      return null;
     }
   };
 
   const sharedChatbotProps = {
     selectedChatId,
-    handleChatSelect,
+    handleChatSelect: activateChat,
     handleForceUpdate,
     forceUpdate,
     isPrivate,
@@ -64,7 +127,7 @@ function HomeChatbot() {
       <div className="w-[20%] px-2">
         <Navbarchatbot
           selectedChatId={selectedChatId}
-          onChatSelect={handleChatSelect}
+          onChatSelect={activateChat}
           handleForceUpdate={handleForceUpdate}
           isPrivate={isPrivate}
           setIsPrivate={setIsPrivate}
@@ -77,7 +140,7 @@ function HomeChatbot() {
           setIsEdit={setIsEdit}
           setShowChatbot={setShowChatbot}
           createNewChat={createNewChat}
-          handleChatSelect={handleChatSelect}
+          handleChatSelect={activateChat}
           forceUpdate={forceUpdate}
         />
       </div>
@@ -106,6 +169,9 @@ function HomeChatbot() {
           <ChatbotTranslation
             selectedChatId={selectedChatId}
             confirmedModelKey={confirmedModelKey}
+            createNewChat={createNewChat}
+            handleChatSelect={activateChat}
+            isPrivate={isPrivate}
           />
         )}
       </div>
@@ -117,7 +183,7 @@ function HomeChatbot() {
             selectedChatId={selectedChatId}
             chat_type={currTask}
             createNewChat={createNewChat}
-            onChatSelect={handleChatSelect}
+            onChatSelect={activateChat}
             handleForceUpdate={handleForceUpdate}
             forceUpdate={forceUpdate}
             setIsPrivate={setIsPrivate}

--- a/frontend/src/financeGPT/components/Installation.js
+++ b/frontend/src/financeGPT/components/Installation.js
@@ -20,12 +20,13 @@ function Installation() {
   const installDependencies = async () => {
     setIsLoading(true);
     try {
-      const response = await fetcher("install-llama-and-mistral", {
+      const response = await fetcher("install-local-model", {
         method: "POST",
         headers: {
           Accept: "application/json",
           "Content-Type": "application/json",
         },
+        body: JSON.stringify({ model_type: 0 }),
       });
       await response.json();
       setIsLoading(false); // Stop loading after fetch completes
@@ -54,7 +55,7 @@ function Installation() {
             <div>Before using PrivateGPT, there are a few installation steps</div>
             <p>Click <a className="underline" target="_blank" rel="noopener noreferrer" href={"https://github.com/ollama/ollama"}>here</a> to download Ollama</p>
             <p>Once downloaded:</p>
-            <div className="w-52 hover:bg-gray-500 cursor-pointer bg-gray-700 p-2 rounded-lg mb-5" onClick={installDependencies}>Install llama2 and Mistral</div>
+            <div className="w-64 hover:bg-gray-500 cursor-pointer bg-gray-700 p-2 rounded-lg mb-5" onClick={installDependencies}>Install the recommended local model</div>
           </div>
           <button onClick={goToHomeChatbot} className="text-xl bg-gray-800 hover:bg-gray-600 w-auto rounded-xl m-2 px-5 py-3 absolute bottom-10 right-10 mb-4 mr-4">
             Continue

--- a/frontend/src/financeGPT/components/NavbarChatbot.js
+++ b/frontend/src/financeGPT/components/NavbarChatbot.js
@@ -60,9 +60,9 @@ function NavbarChatbot(props) {
   };
 
   const handleModelChange = (value) => {
-    const nextModelType = value === "llama2" ? 0 : 1;
+    const nextModelType = Number(value);
 
-    if (nextModelType === props.isPrivate) {
+    if (Number.isNaN(nextModelType) || nextModelType === props.isPrivate) {
       return;
     }
 
@@ -248,10 +248,13 @@ function NavbarChatbot(props) {
               <select
                 className="bg-[#1E2030] rounded-lg border border-gray-700 focus:ring-0 focus:border-[#50B7C3] text-white text-sm cursor-pointer px-2 py-1.5"
                 onChange={(e) => handleModelChange(e.target.value)}
-                value={props.isPrivate === 0 ? "llama2" : "mistral"}
+                value={String(props.isPrivate)}
               >
-                <option value="llama2">LLaMA 2</option>
-                <option value="mistral">Mistral</option>
+                {props.localModels.map((model) => (
+                  <option key={model.id} value={String(model.id)}>
+                    {model.label}
+                  </option>
+                ))}
               </select>
             </div>
           </div>

--- a/frontend/src/financeGPT/components/NavbarChatbot.js
+++ b/frontend/src/financeGPT/components/NavbarChatbot.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import fetcher from "../../http/RequestConfig";
 import ChatHistory from "./ChatHistory";
 import Modal from "../../components/Modal";
@@ -13,20 +13,11 @@ const TASK_TYPES = [
 
 function NavbarChatbot(props) {
   const [showConfirmPopup, setShowConfirmPopup] = useState(false);
-  const [showConfirmModelKey, setShowConfirmModelKey] = useState(false);
   const [showErrorKeyMessage, setShowErrorKeyMessage] = useState(false);
   const [showConfirmResetKey, setShowConfirmResetKey] = useState(false);
+  const [showConfirmModelSwitch, setShowConfirmModelSwitch] = useState(false);
   const [pendingTask, setPendingTask] = useState(null);
-  const [modelKey, setModelKey] = useState("");
-
-  useEffect(() => {
-    props.handleForceUpdate();
-  }, [props.isPrivate]);
-
-  useEffect(() => {
-    setModelKey(props.confirmedModelKey);
-    props.handleForceUpdate();
-  }, [props.confirmedModelKey]);
+  const [pendingModelType, setPendingModelType] = useState(null);
 
   const handleTaskChange = (taskId) => {
     if (taskId !== props.currTask) {
@@ -35,18 +26,12 @@ function NavbarChatbot(props) {
     }
   };
 
-  const confirmSwitchChange = () => {
-    props.setcurrTask(pendingTask);
-    changeChatMode(props.isPrivate);
+  const confirmSwitchChange = async () => {
+    if (pendingTask === null) return;
+
+    await props.createNewChat(pendingTask, props.isPrivate);
     setShowConfirmPopup(false);
     setPendingTask(null);
-  };
-
-  const confirmModelKey = () => {
-    resetChat();
-    props.setConfirmedModelKey(modelKey);
-    addModelKeyToDb(modelKey);
-    setShowConfirmModelKey(false);
   };
 
   const confirmResetModel = () => {
@@ -74,6 +59,37 @@ function NavbarChatbot(props) {
     props.handleForceUpdate();
   };
 
+  const handleModelChange = (value) => {
+    const nextModelType = value === "llama2" ? 0 : 1;
+
+    if (nextModelType === props.isPrivate) {
+      return;
+    }
+
+    if (props.selectedChatId === null) {
+      props.setIsPrivate(nextModelType);
+      return;
+    }
+
+    setPendingModelType(nextModelType);
+    setShowConfirmModelSwitch(true);
+  };
+
+  const confirmModelSwitch = async () => {
+    if (pendingModelType === null) return;
+
+    try {
+      await changeChatMode(pendingModelType);
+      props.setIsPrivate(pendingModelType);
+      props.handleForceUpdate();
+    } catch (e) {
+      console.error("Error switching model:", e);
+    } finally {
+      setPendingModelType(null);
+      setShowConfirmModelSwitch(false);
+    }
+  };
+
   const changeChatMode = async (isPrivate) => {
     try {
       await fetcher("change-chat-mode", {
@@ -92,20 +108,44 @@ function NavbarChatbot(props) {
       <Modal
         isOpen={showConfirmPopup}
         onClose={() => setShowConfirmPopup(false)}
-        title="Switch Mode?"
+        title="Switch Task?"
       >
         <p className="text-gray-300 mb-4">
-          Switching modes will reset your current chat. Are you sure?
+          Switching tasks will start a new chat so your current conversation stays intact.
         </p>
         <div className="flex space-x-3">
           <button
             onClick={confirmSwitchChange}
             className="flex-1 py-2 bg-gradient-to-r from-[#2E5C82] to-[#50B7C3] text-white rounded-lg font-semibold hover:opacity-90"
           >
-            Yes, switch
+            Start new chat
           </button>
           <button
             onClick={() => setShowConfirmPopup(false)}
+            className="flex-1 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
+          >
+            Cancel
+          </button>
+        </div>
+      </Modal>
+
+      <Modal
+        isOpen={showConfirmModelSwitch}
+        onClose={() => setShowConfirmModelSwitch(false)}
+        title="Switch Local Model?"
+      >
+        <p className="text-gray-300 mb-4">
+          Changing the local model will reset the current chat history but keep the attached documents and ticker.
+        </p>
+        <div className="flex space-x-3">
+          <button
+            onClick={confirmModelSwitch}
+            className="flex-1 py-2 bg-gradient-to-r from-[#2E5C82] to-[#50B7C3] text-white rounded-lg font-semibold hover:opacity-90"
+          >
+            Switch model
+          </button>
+          <button
+            onClick={() => setShowConfirmModelSwitch(false)}
             className="flex-1 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600"
           >
             Cancel
@@ -207,7 +247,7 @@ function NavbarChatbot(props) {
               <span className="text-gray-300 text-sm font-medium">Local Model</span>
               <select
                 className="bg-[#1E2030] rounded-lg border border-gray-700 focus:ring-0 focus:border-[#50B7C3] text-white text-sm cursor-pointer px-2 py-1.5"
-                onChange={() => setShowConfirmPopup(true)}
+                onChange={(e) => handleModelChange(e.target.value)}
                 value={props.isPrivate === 0 ? "llama2" : "mistral"}
               >
                 <option value="llama2">LLaMA 2</option>

--- a/frontend/src/financeGPT/components/SidebarChatbot.js
+++ b/frontend/src/financeGPT/components/SidebarChatbot.js
@@ -11,6 +11,8 @@ function SidebarChatbot(props) {
   const [docToDeleteName, setDocToDeleteName] = useState(null);
   const [docToDeleteId, setDocToDeleteId] = useState(null);
 
+  // Documents are refreshed from the active chat context and explicit refresh triggers.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     retrieveDocs();
   }, [props.selectedChatId, props.forceUpdate]);

--- a/frontend/src/financeGPT/components/chatbot_subcomponents/ChatbotEdgar.js
+++ b/frontend/src/financeGPT/components/chatbot_subcomponents/ChatbotEdgar.js
@@ -31,6 +31,8 @@ const ChatbotEdgar = (props) => {
       ? `Hello! I can answer questions about **${ticker}** based on their 10-K filing. How can I help you?`
       : "Hello, I am your financial assistant. Enter a stock ticker above to get started.";
 
+  // The initial mount should render the current chat state once without re-running on each helper redefinition.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     handleLoadChat();
     setIsFirstMessageSent(false);
@@ -39,6 +41,8 @@ const ChatbotEdgar = (props) => {
     ]);
   }, []);
 
+  // EDGAR chat reloads are tied to chat selection changes plus explicit refreshes.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     handleLoadChat();
     setIsFirstMessageSent(false);
@@ -68,15 +72,15 @@ const ChatbotEdgar = (props) => {
   const handleTryMessage = (text, chat_id, isPrivate) => {
     if (!text.trim()) return;
     if (chat_id === null || chat_id === undefined) {
-      props.createNewChat().then((newChatId) => {
-        if (newChatId) handleSendMessage(text, newChatId, isPrivate);
+      props.createNewChat(props.chat_type, isPrivate, false).then((newChat) => {
+        if (newChat?.id) handleSendMessage(text, newChat.id, newChat);
       });
     } else {
-      handleSendMessage(text, chat_id, isPrivate);
+      handleSendMessage(text, chat_id);
     }
   };
 
-  const handleSendMessage = async (text, chat_id) => {
+  const handleSendMessage = async (text, chat_id, newChat = null) => {
     if (inputRef.current) {
       inputRef.current.value = "";
       inputRef.current.style.height = "auto";
@@ -112,11 +116,14 @@ const ChatbotEdgar = (props) => {
         )
       );
 
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
       handleLoadChat();
       scrollToBottom();
 
       if (!isFirstMessageSent) {
-        inferChatName(text, answer);
+        inferChatName(text, answer, chat_id);
         setIsFirstMessageSent(true);
       }
     } catch (e) {
@@ -127,15 +134,18 @@ const ChatbotEdgar = (props) => {
             : msg
         )
       );
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
     }
   };
 
-  const inferChatName = async (text, answer) => {
+  const inferChatName = async (text, answer, chatId = props.selectedChatId) => {
     try {
       const response = await fetcher("infer-chat-name", {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
-        body: JSON.stringify({ messages: text.concat(answer), chat_id: props.selectedChatId, model_type: props.isPrivate }),
+        body: JSON.stringify({ messages: text.concat(answer), chat_id: chatId, model_type: props.isPrivate }),
       });
       const response_data = await response.json();
       props.setCurrChatName(response_data.chat_name);
@@ -146,14 +156,18 @@ const ChatbotEdgar = (props) => {
   };
 
   const handleLoadChat = async () => {
+    setMessages([{ message: welcomeMessage(props.ticker), sentTime: "just now", direction: "incoming" }]);
+
+    if (props.selectedChatId === null || props.selectedChatId === undefined) {
+      return;
+    }
+
     try {
       const response = await fetcher("retrieve-messages-from-chat", {
         method: "POST",
         headers: { Accept: "application/json", "Content-Type": "application/json" },
         body: JSON.stringify({ chat_id: props.selectedChatId, chat_type: props.chat_type }),
       });
-
-      setMessages([{ message: welcomeMessage(props.ticker), sentTime: "just now", direction: "incoming" }]);
 
       const response_data = await response.json();
       const transformedMessages = response_data.messages.map((item) => ({
@@ -162,7 +176,10 @@ const ChatbotEdgar = (props) => {
         relevant_chunks: item.relevant_chunks,
       }));
 
-      setMessages((prev) => [...prev, ...transformedMessages]);
+      setMessages([
+        { message: welcomeMessage(props.ticker), sentTime: "just now", direction: "incoming" },
+        ...transformedMessages,
+      ]);
       setIsFirstMessageSent(transformedMessages.length > 1);
     } catch (error) {
       console.error("Error loading chat messages:", error);

--- a/frontend/src/financeGPT/components/chatbot_subcomponents/ChatbotEdgar.js
+++ b/frontend/src/financeGPT/components/chatbot_subcomponents/ChatbotEdgar.js
@@ -25,6 +25,12 @@ const ChatbotEdgar = (props) => {
   const [isValidTicker, setIsValidTicker] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
+  const [showInstallationModal, setShowInstallationModal] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [timeLeft, setTimeLeft] = useState("");
+  const [installError, setInstallError] = useState("");
+  const installPollTimeoutRef = useRef(null);
 
   const welcomeMessage = (ticker) =>
     ticker
@@ -47,6 +53,14 @@ const ChatbotEdgar = (props) => {
     handleLoadChat();
     setIsFirstMessageSent(false);
   }, [props.selectedChatId, props.forceUpdate]);
+
+  useEffect(() => {
+    return () => {
+      if (installPollTimeoutRef.current) {
+        clearTimeout(installPollTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
@@ -137,6 +151,83 @@ const ChatbotEdgar = (props) => {
       if (newChat) {
         props.handleChatSelect(newChat);
       }
+      setInstallError("");
+      setShowInstallationModal(true);
+    }
+  };
+
+  const resetInstallState = ({ keepModalOpen = false } = {}) => {
+    setIsLoading(false);
+    setProgress(0);
+    setTimeLeft("");
+    if (!keepModalOpen) {
+      setShowInstallationModal(false);
+    }
+    if (installPollTimeoutRef.current) {
+      clearTimeout(installPollTimeoutRef.current);
+      installPollTimeoutRef.current = null;
+    }
+  };
+
+  const pollOllamaStatus = async () => {
+    try {
+      const response = await fetcher("local-model-status", {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ model_type: props.isPrivate }),
+      });
+      const status = await response.json();
+
+      if (status.error) {
+        setInstallError(status.error);
+        resetInstallState({ keepModalOpen: true });
+        return;
+      }
+
+      if (status.model?.installed || status.progress === 100 || (!status.running && status.completed)) {
+        setInstallError("");
+        resetInstallState();
+        props.refreshLocalModels?.();
+      } else {
+        setTimeLeft(status.time_left || "Calculating...");
+        setProgress(status.progress || 0);
+        installPollTimeoutRef.current = setTimeout(pollOllamaStatus, 3000);
+      }
+    } catch (error) {
+      console.error("Failed to fetch install status:", error);
+      setInstallError("Unable to check installation progress. Please verify Ollama is running.");
+      resetInstallState({ keepModalOpen: true });
+    }
+  };
+
+  const installDependencies = async () => {
+    setInstallError("");
+    setProgress(0);
+    setTimeLeft("Preparing download...");
+    setIsLoading(true);
+    try {
+      const response = await fetcher("install-local-model", {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ model_type: props.isPrivate }),
+      });
+      const responseData = await response.json();
+      if (responseData.already_installed) {
+        setInstallError("");
+        resetInstallState();
+        props.refreshLocalModels?.();
+        return;
+      }
+      if (!responseData.success) {
+        setInstallError(responseData.message || "Failed to start the local model download.");
+        resetInstallState({ keepModalOpen: true });
+        return;
+      }
+      pollOllamaStatus();
+    } catch (error) {
+      console.error("Installation failed:", error);
+      setInstallError("Installation failed. Please make sure Ollama is installed, then try again.");
+      resetInstallState({ keepModalOpen: true });
     }
   };
 
@@ -258,6 +349,8 @@ const ChatbotEdgar = (props) => {
     }
   };
 
+  const selectedModelName = props.selectedLocalModel?.label || "Selected Model";
+
   const handleTextareaInput = (e) => {
     e.target.style.height = "auto";
     e.target.style.height = Math.min(e.target.scrollHeight, 120) + "px";
@@ -272,6 +365,39 @@ const ChatbotEdgar = (props) => {
 
   return (
     <div>
+      <Modal
+        isOpen={showInstallationModal}
+        onClose={() => setShowInstallationModal(false)}
+        title={isLoading ? "Installing Model..." : `Install ${selectedModelName}`}
+      >
+        {isLoading ? (
+          <div className="w-full">
+            <div className="w-full bg-gray-700 rounded-full h-3 overflow-hidden mb-2">
+              <div
+                className="h-3 rounded-full transition-all duration-300"
+                style={{ width: `${progress}%`, background: "linear-gradient(90deg, #2E5C82, #50B7C3)" }}
+              />
+            </div>
+            <p className="text-sm text-gray-400">{timeLeft || "Downloading..."}</p>
+          </div>
+        ) : (
+          <p className={`mb-4 ${installError ? "text-red-400" : "text-gray-300"}`}>
+            {installError || `You have not installed ${selectedModelName}. Please install it to use local inference.`}
+          </p>
+        )}
+        <button
+          onClick={installDependencies}
+          disabled={isLoading}
+          className={`mt-4 w-full py-2 rounded-lg font-semibold transition-colors ${
+            isLoading
+              ? "bg-gray-700 text-gray-400 cursor-not-allowed"
+              : "bg-gradient-to-r from-[#2E5C82] to-[#50B7C3] text-white hover:opacity-90"
+          }`}
+        >
+          {isLoading ? "Installing..." : `Download ${selectedModelName}`}
+        </button>
+      </Modal>
+
       {/* Edit ticker confirmation */}
       <Modal
         isOpen={showEditModal}

--- a/frontend/src/financeGPT/components/chatbot_subcomponents/ChatbotTranslation.js
+++ b/frontend/src/financeGPT/components/chatbot_subcomponents/ChatbotTranslation.js
@@ -3,7 +3,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faPaperPlane,
   faLanguage,
-  faRobot,
   faUser,
   faCopy,
   faCheck,
@@ -37,6 +36,11 @@ const LANGUAGES = [
   { code: "Ukrainian", label: "Ukrainian" },
 ];
 
+const WELCOME_MESSAGE = {
+  message: "Hello! I'm your AI translation assistant. Type text below and choose target languages to translate.",
+  direction: "incoming",
+};
+
 function CopyButton({ text }) {
   const [copied, setCopied] = useState(false);
   const handleCopy = () => {
@@ -59,13 +63,40 @@ const ChatbotTranslation = (props) => {
   const [sourceText, setSourceText] = useState("");
   const [targetLang, setTargetLang] = useState("Spanish");
   const [sourceLang, setSourceLang] = useState("English");
-  const [messages, setMessages] = useState([
-    {
-      message: "Hello! I'm your AI translation assistant. Type text below and choose target languages to translate.",
-      direction: "incoming",
-    },
-  ]);
+  const [messages, setMessages] = useState([WELCOME_MESSAGE]);
   const messagesEndRef = useRef(null);
+
+  React.useEffect(() => {
+    const loadTranslationHistory = async () => {
+      setMessages([WELCOME_MESSAGE]);
+
+      if (props.selectedChatId === null || props.selectedChatId === undefined) {
+        return;
+      }
+
+      try {
+        const response = await fetcher("retrieve-messages-from-chat", {
+          method: "POST",
+          headers: { Accept: "application/json", "Content-Type": "application/json" },
+          body: JSON.stringify({
+            chat_id: props.selectedChatId,
+            chat_type: 2,
+          }),
+        });
+        const data = await response.json();
+        const transformedMessages = data.messages.map((item) => ({
+          message: item.message_text,
+          direction: item.sent_from_user === 1 ? "outgoing" : "incoming",
+          translatedText: item.sent_from_user === 0 ? item.message_text : undefined,
+        }));
+        setMessages([WELCOME_MESSAGE, ...transformedMessages]);
+      } catch (error) {
+        console.error("Error loading translation history:", error);
+      }
+    };
+
+    loadTranslationHistory();
+  }, [props.selectedChatId]);
 
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
@@ -73,6 +104,18 @@ const ChatbotTranslation = (props) => {
 
   const handleTranslate = async () => {
     if (!sourceText.trim()) return;
+
+    let chatId = props.selectedChatId;
+    let newChat = null;
+
+    if (chatId === null || chatId === undefined) {
+      newChat = await props.createNewChat(2, props.isPrivate, false);
+      chatId = newChat?.id;
+    }
+
+    if (chatId === null || chatId === undefined) {
+      return;
+    }
 
     const tempId = Date.now();
     setMessages((prev) => [
@@ -91,7 +134,7 @@ const ChatbotTranslation = (props) => {
           text: sourceText,
           source_language: sourceLang,
           target_language: targetLang,
-          chat_id: props.selectedChatId,
+          chat_id: chatId,
           model_key: props.confirmedModelKey,
         }),
       });
@@ -105,6 +148,11 @@ const ChatbotTranslation = (props) => {
             : msg
         )
       );
+
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
+
       scrollToBottom();
     } catch (e) {
       setMessages((prev) =>
@@ -114,6 +162,9 @@ const ChatbotTranslation = (props) => {
             : msg
         )
       );
+      if (newChat) {
+        props.handleChatSelect(newChat);
+      }
     }
   };
 

--- a/frontend/src/subcomponents/payments/Pricing.js
+++ b/frontend/src/subcomponents/payments/Pricing.js
@@ -48,7 +48,7 @@ const Pricing = (props) => {
         price: "$1,000",
         month: true,
         features: [
-          "Privacy-preserving LLM using a more powerful model like LLAMA2",
+          "Privacy-preserving LLM using a more powerful modern open local model",
           "Support for larger file upload sizes to handle more data",
           "Supported Text File Formats: All text file types (e.g., PDFs, TXT files, DOCX files, etc.)",
           "Maximum Number of Files: Up to 50 files per session",


### PR DESCRIPTION
## What this PR does

This PR refreshes the app's local AI experience by replacing outdated Ollama assumptions with a more modern, local-first model workflow.

Instead of hardcoding older model choices like `llama2` and `mistral`, the app now uses a centralized local model registry and defaults to stronger current local options:
- `qwen3:8b`
- `llama3.1:8b`

It also removes the remaining OpenAI dependency from document embeddings, so the local chat experience is much closer to being truly private end-to-end.

## Why this matters

The previous implementation worked, but it was starting to show its age:
- local model choices were outdated
- model install/status logic was duplicated and tightly coupled to specific names
- local document chat still relied on OpenAI embeddings
- adding or swapping local models would have required touching multiple frontend and backend paths

This PR makes the product easier to maintain and gives users a more coherent privacy-preserving local workflow.

## Main changes

### Local model management
- introduced a single backend source of truth for local chat models
- added generic endpoints for listing models, installing them, and checking install status
- kept legacy endpoints/fields for backward compatibility

### Chat and retrieval pipeline
- routed local chat requests through the selected registered local model
- updated chat title inference to use the same local model fallback flow
- switched document embeddings from OpenAI to local Ollama embeddings

### Frontend product experience
- made the model selector dynamic instead of hardcoded
- updated install modals to reflect the currently selected model
- reused the same generic install/status flow across PDF chat and EDGAR chat
- improved initial state loading so the most recent chat/model restore more reliably
- cleaned up outdated product copy that referenced older model branding

## Impact

This improves the product in three ways:
- better defaults for new users
- a more private local experience
- a cleaner foundation for future model upgrades

## Validation

Checked in this branch:
- `python3 -m py_compile backend/app.py backend/local_models.py backend/api_endpoints/financeGPT/chatbot_endpoints.py`
- `npm test -- --watchAll=false`
- `npm run build`

## Notes

- legacy compatibility fields such as `llama2_exists` and `mistral_exists` are still returned for older callers
- `frontend/package-lock.json` was intentionally not included in this PR
- backend `pytest` was not fully runnable in the current machine environment because the available Python environments are missing either `pytest` or Flask dependencies